### PR TITLE
List namespaces from kube-state-metrics

### DIFF
--- a/elasticsearch/elasticsearch_database_dashboard.json
+++ b/elasticsearch/elasticsearch_database_dashboard.json
@@ -2008,7 +2008,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2017,7 +2017,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/elasticsearch/elasticsearch_pod_dashboard.json
+++ b/elasticsearch/elasticsearch_pod_dashboard.json
@@ -2187,7 +2187,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2196,7 +2196,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/elasticsearch/elasticsearch_summary_dashboard.json
@@ -2687,7 +2687,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2696,7 +2696,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-database.json
+++ b/mariadb/mariadb-database.json
@@ -1427,7 +1427,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1436,7 +1436,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-galera.json
+++ b/mariadb/mariadb-galera.json
@@ -539,7 +539,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -548,7 +548,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-pod.json
+++ b/mariadb/mariadb-pod.json
@@ -3443,7 +3443,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3452,7 +3452,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-summary.json
+++ b/mariadb/mariadb-summary.json
@@ -2634,7 +2634,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2643,7 +2643,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mongodb/legacy/mongodb-database-replset-dashboard.json
+++ b/mongodb/legacy/mongodb-database-replset-dashboard.json
@@ -1258,7 +1258,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1267,7 +1267,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mongodb/legacy/mongodb-pod-dashboard.json
+++ b/mongodb/legacy/mongodb-pod-dashboard.json
@@ -1817,7 +1817,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1826,7 +1826,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mongodb/legacy/mongodb-summary-dashboard.json
+++ b/mongodb/legacy/mongodb-summary-dashboard.json
@@ -2630,7 +2630,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2639,7 +2639,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mongodb/mongodb-database-replset-dashboard.json
+++ b/mongodb/mongodb-database-replset-dashboard.json
@@ -1256,7 +1256,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1266,7 +1266,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(namespace)",
+          "query": "label_values(kube_namespace_labels,namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mongodb/mongodb-pod-dashboard.json
+++ b/mongodb/mongodb-pod-dashboard.json
@@ -1817,7 +1817,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1827,7 +1827,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(namespace)",
+          "query": "label_values(kube_namespace_labels,namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mongodb/mongodb-summary-dashboard.json
+++ b/mongodb/mongodb-summary-dashboard.json
@@ -2630,7 +2630,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2639,7 +2639,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_database_dashboard.json
+++ b/mysql/mysql_database_dashboard.json
@@ -1257,7 +1257,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1266,7 +1266,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_group_replication.json
+++ b/mysql/mysql_group_replication.json
@@ -1567,7 +1567,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1576,7 +1576,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_pod_dashboard.json
+++ b/mysql/mysql_pod_dashboard.json
@@ -3443,7 +3443,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3452,7 +3452,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_summary_dashboard.json
+++ b/mysql/mysql_summary_dashboard.json
@@ -2717,7 +2717,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2726,7 +2726,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-database.json
+++ b/perconaxtradb/perconaxtradb-database.json
@@ -1427,7 +1427,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1436,7 +1436,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-galera.json
+++ b/perconaxtradb/perconaxtradb-galera.json
@@ -539,7 +539,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -548,7 +548,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-pod.json
+++ b/perconaxtradb/perconaxtradb-pod.json
@@ -3443,7 +3443,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3452,7 +3452,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-summary.json
+++ b/perconaxtradb/perconaxtradb-summary.json
@@ -2634,7 +2634,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2643,7 +2643,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/postgres/postgres_databases_dashboard.json
+++ b/postgres/postgres_databases_dashboard.json
@@ -1790,7 +1790,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1799,7 +1799,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/postgres/postgres_pods_dashboard.json
+++ b/postgres/postgres_pods_dashboard.json
@@ -1585,7 +1585,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1594,7 +1594,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/postgres/postgres_summary_dashboard.json
+++ b/postgres/postgres_summary_dashboard.json
@@ -2877,7 +2877,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2886,7 +2886,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/redis/redis_summary_dashboard.json
+++ b/redis/redis_summary_dashboard.json
@@ -2990,7 +2990,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(kube_namespace_labels,namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2999,7 +2999,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(kube_namespace_labels,namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
This ensures Rancher project dashboards only show relevant namespaces

xref: https://github.com/kubernetes/kube-state-metrics/blob/master/docs/namespace-metrics.md

Signed-off-by: Tamal Saha <tamal@appscode.com>