### PR TITLE
Replace denylisted kube-state-metrics in dashboards

### DIFF
--- a/cassandra/cassandra_summary_dashboard.json
+++ b/cassandra/cassandra_summary_dashboard.json
@@ -2866,7 +2866,7 @@
           "value": "cassandra"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/clickhouse/clickhouse-database.json
+++ b/clickhouse/clickhouse-database.json
@@ -1913,7 +1913,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1923,7 +1923,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/clickhouse/clickhouse-pod.json
+++ b/clickhouse/clickhouse-pod.json
@@ -1772,7 +1772,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1782,7 +1782,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/clickhouse/clickhouse-summary.json
+++ b/clickhouse/clickhouse-summary.json
@@ -2870,7 +2870,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2880,7 +2880,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/connectcluster/connectcluster-connect.json
+++ b/connectcluster/connectcluster-connect.json
@@ -2727,7 +2727,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2737,7 +2737,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/connectcluster/connectcluster-pod.json
+++ b/connectcluster/connectcluster-pod.json
@@ -3723,7 +3723,7 @@
           "value": "demo"
         },
         "datasource": null,
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3733,7 +3733,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/connectcluster/connectcluster-summary.json
+++ b/connectcluster/connectcluster-summary.json
@@ -2671,7 +2671,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/druid/druid_database_dashboard.json
+++ b/druid/druid_database_dashboard.json
@@ -1227,7 +1227,7 @@
       {
         "allValue": null,
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,

--- a/druid/druid_pod_dashboard.json
+++ b/druid/druid_pod_dashboard.json
@@ -768,7 +768,7 @@
           "value": "druid"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -778,7 +778,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/druid/druid_summary_dashboard.json
+++ b/druid/druid_summary_dashboard.json
@@ -2866,7 +2866,7 @@
           "value": "druid"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/elasticsearch/elasticsearch_database_dashboard.json
+++ b/elasticsearch/elasticsearch_database_dashboard.json
@@ -2007,7 +2007,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2016,7 +2016,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/elasticsearch/elasticsearch_pod_dashboard.json
+++ b/elasticsearch/elasticsearch_pod_dashboard.json
@@ -2186,7 +2186,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2195,7 +2195,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/elasticsearch/elasticsearch_summary_dashboard.json
@@ -3018,7 +3018,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3028,7 +3028,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/falco/app-level-events.json
+++ b/falco/app-level-events.json
@@ -650,7 +650,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -660,7 +660,7 @@
         "name": "ns",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/falco/namespace-level-events.json
+++ b/falco/namespace-level-events.json
@@ -339,7 +339,7 @@
           "value": ""
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -349,7 +349,7 @@
         "name": "ns",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/ferretdb/ferretdb-summary-dashboard.json
+++ b/ferretdb/ferretdb-summary-dashboard.json
@@ -2923,7 +2923,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2933,7 +2933,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/hazelcast/hazelcast_database_dashboard.json
+++ b/hazelcast/hazelcast_database_dashboard.json
@@ -1572,7 +1572,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1582,7 +1582,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/hazelcast/hazelcast_pod_dashboard.json
+++ b/hazelcast/hazelcast_pod_dashboard.json
@@ -1304,7 +1304,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1314,7 +1314,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/hazelcast/hazelcast_summary_dashboard.json
+++ b/hazelcast/hazelcast_summary_dashboard.json
@@ -2947,7 +2947,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2957,7 +2957,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/ignite/ignite_summary_dashboard.json
+++ b/ignite/ignite_summary_dashboard.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/kafka/kafka_database_dashboard.json
+++ b/kafka/kafka_database_dashboard.json
@@ -2574,7 +2574,7 @@
           "value": "kafka"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2584,7 +2584,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/kafka/kafka_pod_dashboard.json
+++ b/kafka/kafka_pod_dashboard.json
@@ -1632,7 +1632,7 @@
           "value": "kafka"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1642,7 +1642,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/kafka/kafka_summary.json
+++ b/kafka/kafka_summary.json
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/kubevault/vaultserver_summary_dashboard.json
+++ b/kubevault/vaultserver_summary_dashboard.json
@@ -4078,7 +4078,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -4088,7 +4088,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mariadb/mariadb-database.json
+++ b/mariadb/mariadb-database.json
@@ -1426,7 +1426,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1435,7 +1435,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-galera.json
+++ b/mariadb/mariadb-galera.json
@@ -538,7 +538,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -547,7 +547,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-pod.json
+++ b/mariadb/mariadb-pod.json
@@ -3442,7 +3442,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3451,7 +3451,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mariadb/mariadb-standard-replication.json
+++ b/mariadb/mariadb-standard-replication.json
@@ -1091,7 +1091,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1101,7 +1101,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mariadb/mariadb-summary.json
+++ b/mariadb/mariadb-summary.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/memcached/memcached_summary_dashboard.json
+++ b/memcached/memcached_summary_dashboard.json
@@ -2313,7 +2313,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2323,7 +2323,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mongodb/mongodb-database-replset-dashboard.json
+++ b/mongodb/mongodb-database-replset-dashboard.json
@@ -1256,7 +1256,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1266,7 +1266,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mongodb/mongodb-pod-dashboard.json
+++ b/mongodb/mongodb-pod-dashboard.json
@@ -1817,7 +1817,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1827,7 +1827,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mongodb/mongodb-summary-dashboard.json
+++ b/mongodb/mongodb-summary-dashboard.json
@@ -2923,7 +2923,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2933,7 +2933,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mssqlserver/mssqlserver_database_dashboard.json
+++ b/mssqlserver/mssqlserver_database_dashboard.json
@@ -1208,7 +1208,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1218,7 +1218,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mssqlserver/mssqlserver_summary_dashboard.json
+++ b/mssqlserver/mssqlserver_summary_dashboard.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/mysql/mysql_database_dashboard.json
+++ b/mysql/mysql_database_dashboard.json
@@ -1256,7 +1256,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1265,7 +1265,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_group_replication.json
+++ b/mysql/mysql_group_replication.json
@@ -1566,7 +1566,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1575,7 +1575,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_pod_dashboard.json
+++ b/mysql/mysql_pod_dashboard.json
@@ -3442,7 +3442,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3451,7 +3451,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mysql/mysql_summary_dashboard.json
+++ b/mysql/mysql_summary_dashboard.json
@@ -2949,7 +2949,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2959,7 +2959,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/neo4j/neo4j-database.json
+++ b/neo4j/neo4j-database.json
@@ -2872,7 +2872,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2882,7 +2882,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/neo4j/neo4j-pod.json
+++ b/neo4j/neo4j-pod.json
@@ -3169,7 +3169,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3179,7 +3179,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/neo4j/neo4j-summary.json
+++ b/neo4j/neo4j-summary.json
@@ -2833,7 +2833,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2843,7 +2843,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/oracle/oracle_database_dashboard.json
+++ b/oracle/oracle_database_dashboard.json
@@ -1209,7 +1209,7 @@
           "value": "exporter"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1219,7 +1219,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/oracle/oracle_pod_dashboard.json
+++ b/oracle/oracle_pod_dashboard.json
@@ -1537,7 +1537,7 @@
           "value": "exporter"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1547,7 +1547,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,

--- a/oracle/oracle_summary_dashboard.json
+++ b/oracle/oracle_summary_dashboard.json
@@ -2924,7 +2924,7 @@
           "value": "exporter"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2934,7 +2934,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/perconaxtradb/perconaxtradb-database.json
+++ b/perconaxtradb/perconaxtradb-database.json
@@ -1426,7 +1426,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1435,7 +1435,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-galera.json
+++ b/perconaxtradb/perconaxtradb-galera.json
@@ -538,7 +538,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -547,7 +547,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-pod.json
+++ b/perconaxtradb/perconaxtradb-pod.json
@@ -3442,7 +3442,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3451,7 +3451,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/perconaxtradb/perconaxtradb-summary.json
+++ b/perconaxtradb/perconaxtradb-summary.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pgbouncer/pgbouncer_database.json
+++ b/pgbouncer/pgbouncer_database.json
@@ -990,7 +990,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1000,7 +1000,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pgbouncer/pgbouncer_pod.json
+++ b/pgbouncer/pgbouncer_pod.json
@@ -963,7 +963,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -973,7 +973,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pgbouncer/pgbouncer_summary.json
+++ b/pgbouncer/pgbouncer_summary.json
@@ -2318,7 +2318,7 @@
           "value": "pool"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2328,7 +2328,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pgpool/pgpool_database.json
+++ b/pgpool/pgpool_database.json
@@ -2610,7 +2610,7 @@
           "value": "pool"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2620,7 +2620,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pgpool/pgpool_pod.json
+++ b/pgpool/pgpool_pod.json
@@ -963,7 +963,7 @@
           "value": "pool"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -973,7 +973,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/pgpool/pgpool_summary.json
+++ b/pgpool/pgpool_summary.json
@@ -2318,7 +2318,7 @@
           "value": "pool"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2328,7 +2328,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/policy/namespace-violations.json
+++ b/policy/namespace-violations.json
@@ -243,7 +243,7 @@
           "value": "cert-manager"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -253,7 +253,7 @@
         "name": "ns",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/postgres/postgres_databases_dashboard.json
+++ b/postgres/postgres_databases_dashboard.json
@@ -1789,7 +1789,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1798,7 +1798,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/postgres/postgres_pods_dashboard.json
+++ b/postgres/postgres_pods_dashboard.json
@@ -1584,7 +1584,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1593,7 +1593,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_created,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/postgres/postgres_summary_dashboard.json
+++ b/postgres/postgres_summary_dashboard.json
@@ -3432,7 +3432,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3442,7 +3442,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/proxysql/proxysql-database.json
+++ b/proxysql/proxysql-database.json
@@ -7743,7 +7743,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -7753,7 +7753,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/proxysql/proxysql-pod.json
+++ b/proxysql/proxysql-pod.json
@@ -1238,7 +1238,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1248,7 +1248,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/proxysql/proxysql-summary.json
+++ b/proxysql/proxysql-summary.json
@@ -2317,7 +2317,7 @@
             "value": "demo"
           },
           "datasource": "${datasource}",
-          "definition": "label_values(kube_namespace_created,namespace)",
+          "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "description": null,
           "error": null,
           "hide": 0,
@@ -2327,7 +2327,7 @@
           "name": "namespace",
           "options": [],
           "query": {
-            "query": "label_values(kube_namespace_created,namespace)",
+            "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
             "refId": "Prometheus-namespace-Variable-Query"
           },
           "refresh": 1,

--- a/qdrant/qdrant_database_dashboard.json
+++ b/qdrant/qdrant_database_dashboard.json
@@ -1265,7 +1265,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1275,7 +1275,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/qdrant/qdrant_pod_dashboard.json
+++ b/qdrant/qdrant_pod_dashboard.json
@@ -1537,7 +1537,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1547,7 +1547,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/qdrant/qdrant_summary_dashboard.json
+++ b/qdrant/qdrant_summary_dashboard.json
@@ -2867,7 +2867,7 @@
           "value": "default"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2877,7 +2877,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/rabbitmq/rabbitmq-database.json
+++ b/rabbitmq/rabbitmq-database.json
@@ -15319,7 +15319,7 @@
                 "value": "rabbit"
               },
               "datasource": "${datasource}",
-              "definition": "label_values(kube_namespace_created,namespace)",
+              "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
               "description": null,
               "error": null,
               "hide": 0,
@@ -15329,7 +15329,7 @@
               "name": "namespace",
               "options": [],
               "query": {
-                "query": "label_values(kube_namespace_created,namespace)",
+                "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
                 "refId": "Prometheus-namespace-Variable-Query"
               },
               "refresh": 1,
@@ -17954,7 +17954,7 @@
           "value": "rabbit"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -17964,7 +17964,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/rabbitmq/rabbitmq-pod.json
+++ b/rabbitmq/rabbitmq-pod.json
@@ -1417,7 +1417,7 @@
           "value": "rabbit"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1427,7 +1427,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/rabbitmq/rabbitmq-summary.json
+++ b/rabbitmq/rabbitmq-summary.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/redis/redis_summary_dashboard.json
+++ b/redis/redis_summary_dashboard.json
@@ -3351,7 +3351,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3361,7 +3361,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/redis/sentinel_summary_dashbaord.json
+++ b/redis/sentinel_summary_dashbaord.json
@@ -3019,7 +3019,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3029,7 +3029,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/scanner/app-level-cves.json
+++ b/scanner/app-level-cves.json
@@ -316,7 +316,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created{},namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -326,7 +326,7 @@
         "name": "ns",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created{},namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/scanner/namespace-level-cves.json
+++ b/scanner/namespace-level-cves.json
@@ -256,7 +256,7 @@
           "value": ""
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -266,7 +266,7 @@
         "name": "ns",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/singlestore/singlestore_database_dashboard.json
+++ b/singlestore/singlestore_database_dashboard.json
@@ -1014,7 +1014,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1024,7 +1024,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/singlestore/singlestore_pod_dashboard.json
+++ b/singlestore/singlestore_pod_dashboard.json
@@ -2538,7 +2538,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2548,7 +2548,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/singlestore/singlestore_summary_dashboard.json
+++ b/singlestore/singlestore_summary_dashboard.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/solr/solr-database.json
+++ b/solr/solr-database.json
@@ -3312,7 +3312,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3322,7 +3322,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/solr/solr-pod.json
+++ b/solr/solr-pod.json
@@ -6718,7 +6718,7 @@
             "value": "demo"
           },
           "datasource": "${datasource}",
-          "definition": "label_values(kube_namespace_created,namespace)",
+          "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "description": null,
           "error": null,
           "hide": 0,
@@ -6728,7 +6728,7 @@
           "name": "namespace",
           "options": [],
           "query": {
-            "query": "label_values(kube_namespace_created,namespace)",
+            "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
             "refId": "Prometheus-namespace-Variable-Query"
           },
           "refresh": 1,

--- a/solr/solr-summary.json
+++ b/solr/solr-summary.json
@@ -2946,7 +2946,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2956,7 +2956,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/zookeeper/zookeeper_ensemble_dashboard.json
+++ b/zookeeper/zookeeper_ensemble_dashboard.json
@@ -9378,7 +9378,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -9388,7 +9388,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/zookeeper/zookeeper_pod_dashboard.json
+++ b/zookeeper/zookeeper_pod_dashboard.json
@@ -9904,7 +9904,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -9914,7 +9914,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/zookeeper/zookeeper_summary_dashboard.json
+++ b/zookeeper/zookeeper_summary_dashboard.json
@@ -3013,7 +3013,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3023,7 +3023,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,


### PR DESCRIPTION
## Summary
- replace denylisted kube_namespace_created with kube_namespace_status_phase
- update namespace variable queries to filter phase="Active"
- keep dashboard namespace template variables functional while aligning with kube-state-metrics denylist

## Validation
- denylist scan over dashboard JSON files returns 0 matches
- updated 81 files (161 query replacements)

## Notes
- branch pushed to repository's redirected location: ops-center/grafana-dashboards
