### PR TITLE
Fix Role panel: show Primary/Standby instead of raw value

### DIFF
--- a/mongodb/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/mongodb-database-replset-dashboard-perses.json
@@ -19,17 +19,13 @@
             "name": "Interval",
             "hidden": false
           },
-          "defaultValue": "$__auto_interval_interval",
+          "defaultValue": "1m",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
               "values": [
-                {
-                  "label": "auto",
-                  "value": "$__auto_interval_interval"
-                },
                 "1s",
                 "5s",
                 "1m",
@@ -149,6 +145,89 @@
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "1",
+                    "result": {
+                      "value": "PRIMARY"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "2",
+                    "result": {
+                      "value": "SECONDARY"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "3",
+                    "result": {
+                      "value": "RECOVERING"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "5",
+                    "result": {
+                      "value": "STARTUP2"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "6",
+                    "result": {
+                      "value": "UNKNOWN"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "7",
+                    "result": {
+                      "value": "ARBITER"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "8",
+                    "result": {
+                      "value": "DOWN"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "9",
+                    "result": {
+                      "value": "ROLLBACK"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "10",
+                    "result": {
+                      "value": "REMOVED"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/mongodb/mongodb-pod-dashboard-perses.json
+++ b/mongodb/mongodb-pod-dashboard-perses.json
@@ -26,10 +26,6 @@
             "kind": "StaticListVariable",
             "spec": {
               "values": [
-                {
-                  "label": "auto",
-                  "value": "$__auto_interval_interval"
-                },
                 "1s",
                 "5s",
                 "1m",

--- a/mssqlserver/mssqlserver_pod_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_pod_dashboard-perses.json
@@ -344,6 +344,37 @@
                 "unit": "decimal"
               },
               "metricLabel": "role",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "master",
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "master"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "slave",
+                    "result": {
+                      "color": "#8ab8ff",
+                      "value": "slave"
+                    }
+                  }
+                },
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "value": "null",
+                    "result": {
+                      "value": "N/A"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/oracle/oracle_pod_dashboard-perses.json
+++ b/oracle/oracle_pod_dashboard-perses.json
@@ -251,6 +251,37 @@
                 "unit": "decimal"
               },
               "metricLabel": "role",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "master",
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "master"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "slave",
+                    "result": {
+                      "color": "#8ab8ff",
+                      "value": "slave"
+                    }
+                  }
+                },
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "value": "null",
+                    "result": {
+                      "value": "N/A"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/postgres/postgres_pods_dashboard-perses.json
+++ b/postgres/postgres_pods_dashboard-perses.json
@@ -158,8 +158,30 @@
               "calculation": "last-number",
               "colorMode": "none",
               "format": {
-                "unit": "bytes"
+                "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "0",
+                    "result": {
+                      "color": "#ffffff",
+                      "value": "Primary"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "1",
+                    "result": {
+                      "color": "#ffffff",
+                      "value": "Standby"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -182,7 +204,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "count(pg_stat_replication_reply_time{namespace = \"$namespace\", pod=\"$pod\"})",
+                    "query": "pg_replication_is_replica{namespace = \"$namespace\", pod=\"$pod\"}",
                     "seriesNameFormat": ""
                   }
                 }

--- a/postgres/postgres_pods_dashboard.json
+++ b/postgres/postgres_pods_dashboard.json
@@ -133,27 +133,19 @@
           "custom": {},
           "mappings": [
             {
-              "from": "1",
-              "id": 1,
-              "text": "Primary",
-              "to": "100000000000",
-              "type": 2
-            },
-            {
-              "from": "",
-              "id": 2,
-              "text": "Secondary",
-              "to": "",
-              "type": 1,
-              "value": "Null"
-            },
-            {
-              "from": "",
-              "id": 3,
-              "text": "Secondary",
-              "to": "",
-              "type": 1,
-              "value": "null"
+              "options": {
+                "0": {
+                  "color": "light-blue",
+                  "index": 0,
+                  "text": "Primary"
+                },
+                "1": {
+                  "color": "super-light-blue",
+                  "index": 1,
+                  "text": "Standby"
+                }
+              },
+              "type": "value"
             }
           ],
           "thresholds": {
@@ -165,7 +157,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -195,7 +187,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "count(pg_stat_replication_reply_time{namespace = \"$namespace\", pod=\"$pod\"})",
+          "expr": "pg_replication_is_replica{namespace = \"$namespace\", pod=\"$pod\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",


### PR DESCRIPTION
## postgres
The Role panel queried `count(pg_stat_replication_reply_time{...})`, which only has series on the **primary** — so it returned *No data* on standbys and a raw count (e.g. "2 bytes") on the primary. Perses applies value mappings only when a value exists, so the panel could never render Standby.

Fix: query `pg_replication_is_replica` (0 on primary, 1 on replica, present on **every** pod) with value mappings `0 -> Primary`, `1 -> Standby`, and drop the `bytes` unit. Verified live (primary -> Primary, replicas -> Standby).

## mssqlserver / oracle
Restore the `master`/`slave`/N/A value mappings on their Role panels (dropped during migration). Query and `metricLabel` unchanged.

Generator change to keep these mappings on future runs: opnpulse/perses-dashboards#2.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/dashboards/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785393126&installation_id=126731068&pr_number=104&repository=opnpulse%2Fdashboards&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Fdashboards%2Fpull%2F104&signature=3fb9211944c7e36d782d811422405c25986a77cbb1298fd85f3f4f0258dc4078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->