### PR TITLE
fix(perconaxtradb): use regex matcher for pod var in Pod CPU/Memory/F…

### DIFF
--- a/perconaxtradb/perconaxtradb-pod-perses.json
+++ b/perconaxtradb/perconaxtradb-pod-perses.json
@@ -1559,7 +1559,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
+                    "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
                     "seriesNameFormat": "{{container}}"
                   }
                 }
@@ -1596,7 +1596,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
                     "seriesNameFormat": "{{pod}}"
                   }
                 }
@@ -1634,7 +1634,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "sum(process_open_fds{pod=\"$pod\", namespace=\"$namespace\"}) by (pod)",
+                    "query": "sum(process_open_fds{pod=~\"$pod\", namespace=\"$namespace\"}) by (pod)",
                     "seriesNameFormat": "{{pod}}"
                   }
                 }

--- a/perconaxtradb/perconaxtradb-pod-perses.json
+++ b/perconaxtradb/perconaxtradb-pod-perses.json
@@ -793,7 +793,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
                     "seriesNameFormat": "InnoDB Buffer Pool Size - {{pod}}"
                   }
                 }
@@ -810,7 +810,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "mysql_global_variables_innodb_log_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "query": "mysql_global_variables_innodb_log_buffer_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
                     "seriesNameFormat": "InnoDB Log Buffer Size - {{pod}}"
                   }
                 }
@@ -827,7 +827,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "mysql_global_status_innodb_mem_dictionary{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "query": "mysql_global_status_innodb_mem_dictionary{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
                     "seriesNameFormat": "InnoDB Dictionary Size - {{pod}}"
                   }
                 }
@@ -844,7 +844,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "mysql_global_variables_key_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "query": "mysql_global_variables_key_buffer_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
                     "seriesNameFormat": "Key Buffer Size - {{pod}}"
                   }
                 }
@@ -861,7 +861,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "mysql_global_variables_query_cache_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "query": "mysql_global_variables_query_cache_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
                     "seriesNameFormat": "Query Cache Size - {{pod}}"
                   }
                 }
@@ -878,7 +878,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "mysql_global_status_innodb_mem_adaptive_hash{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "query": "mysql_global_status_innodb_mem_adaptive_hash{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
                     "seriesNameFormat": "Adaptive Hash Index Size - {{pod}}"
                   }
                 }

--- a/perconaxtradb/perconaxtradb-pod.json
+++ b/perconaxtradb/perconaxtradb-pod.json
@@ -2149,7 +2149,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "mysql_global_variables_innodb_buffer_pool_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+          "expr": "mysql_global_variables_innodb_buffer_pool_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "InnoDB Buffer Pool Size - {{pod}}",
@@ -2157,7 +2157,7 @@
         },
         {
           "exemplar": true,
-          "expr": "mysql_global_variables_innodb_log_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+          "expr": "mysql_global_variables_innodb_log_buffer_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "InnoDB Log Buffer Size - {{pod}}",
@@ -2165,7 +2165,7 @@
         },
         {
           "exemplar": true,
-          "expr": "mysql_global_status_innodb_mem_dictionary{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+          "expr": "mysql_global_status_innodb_mem_dictionary{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "InnoDB Dictionary Size - {{pod}}",
@@ -2173,7 +2173,7 @@
         },
         {
           "exemplar": false,
-          "expr": "mysql_global_variables_key_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+          "expr": "mysql_global_variables_key_buffer_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Key Buffer Size - {{pod}}",
@@ -2181,7 +2181,7 @@
         },
         {
           "exemplar": true,
-          "expr": "mysql_global_variables_query_cache_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+          "expr": "mysql_global_variables_query_cache_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Query Cache Size - {{pod}}",
@@ -2189,7 +2189,7 @@
         },
         {
           "exemplar": true,
-          "expr": "mysql_global_status_innodb_mem_adaptive_hash{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+          "expr": "mysql_global_status_innodb_mem_adaptive_hash{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "Adaptive Hash Index Size - {{pod}}",

--- a/perconaxtradb/perconaxtradb-pod.json
+++ b/perconaxtradb/perconaxtradb-pod.json
@@ -420,7 +420,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
           "interval": "",
           "legendFormat": "{{container}}",
           "refId": "A"
@@ -517,7 +517,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
+          "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -615,7 +615,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(process_open_fds{pod=\"$pod\", namespace=\"$namespace\"}) by (pod)",
+          "expr": "sum(process_open_fds{pod=~\"$pod\", namespace=\"$namespace\"}) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"


### PR DESCRIPTION
…D panels

The CPU Usage, Memory Usage, and Open File Descriptors panels matched the pod label with an exact matcher (pod="$pod"). When the Pod template variable is set to "All" (multi-value, includeAll), Grafana/Perses expands it to a regex/pipe-joined value that an exact matcher cannot satisfy, so the panels showed "No data".

Switch these three queries to the regex matcher (pod=~"$pod"), matching the rest of the dashboard, so All and multi-select render one series per pod. Applied to both the Grafana and Perses variants.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/dashboards/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786530645&installation_id=126731068&pr_number=107&repository=opnpulse%2Fdashboards&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Fdashboards%2Fpull%2F107&signature=f34acc55ac08767107b03acc9d976730c91493f358eedcff5f6eb16aaecb8ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->