### PR TITLE
Give each dashboard a unique, deterministic identity

### DIFF
--- a/cassandra/cassandra_database_dashboard-perses.json
+++ b/cassandra/cassandra_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "PbhrxMuiz",
+    "name": "kubedb-cassandra-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/cassandra/cassandra_database_dashboard.json
+++ b/cassandra/cassandra_database_dashboard.json
@@ -3981,6 +3981,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Cassandra / Database",
-  "uid": "PbhrxMuiz",
+  "uid": "kubedb-cassandra-database",
   "version": 1
 }

--- a/cassandra/cassandra_pod_dashboard-perses.json
+++ b/cassandra/cassandra_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "PbhrxMuiz",
+    "name": "kubedb-cassandra-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/cassandra/cassandra_pod_dashboard.json
+++ b/cassandra/cassandra_pod_dashboard.json
@@ -2323,6 +2323,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Cassandra / Pod",
-  "uid": "PbhrxMuiz",
+  "uid": "kubedb-cassandra-pod",
   "version": 1
 }

--- a/cassandra/cassandra_summary_dashboard-perses.json
+++ b/cassandra/cassandra_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "cassandraSummary",
+    "name": "kubedb-cassandra-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/cassandra/cassandra_summary_dashboard.json
+++ b/cassandra/cassandra_summary_dashboard.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Cassandra / Summary",
-  "uid": "cassandraSummary",
+  "uid": "kubedb-cassandra-summary",
   "version": 7
 }

--- a/clickhouse/clickhouse-database-perses.json
+++ b/clickhouse/clickhouse-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "clickhouseDatabase",
+    "name": "kubedb-clickhouse-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/clickhouse/clickhouse-database.json
+++ b/clickhouse/clickhouse-database.json
@@ -1976,6 +1976,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / ClickHouse / Database",
-  "uid": "clickhouseDatabase",
+  "uid": "kubedb-clickhouse-database",
   "version": 1
 }

--- a/clickhouse/clickhouse-pod-perses.json
+++ b/clickhouse/clickhouse-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "clickhousePodSummary",
+    "name": "kubedb-clickhouse-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/clickhouse/clickhouse-pod.json
+++ b/clickhouse/clickhouse-pod.json
@@ -1866,6 +1866,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / ClickHouse / Pod",
-  "uid": "clickhousePodSummary",
+  "uid": "kubedb-clickhouse-pod",
   "version": 3
 }

--- a/clickhouse/clickhouse-summary-perses.json
+++ b/clickhouse/clickhouse-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "clickhouseSummary",
+    "name": "kubedb-clickhouse-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/clickhouse/clickhouse-summary.json
+++ b/clickhouse/clickhouse-summary.json
@@ -2957,6 +2957,6 @@
   },
   "timezone": "",
   "title": "KubeDB / ClickHouse / Summary",
-  "uid": "clickhouseSummary",
+  "uid": "kubedb-clickhouse-summary",
   "version": 2
 }

--- a/connectcluster/connectcluster-connect-perses.json
+++ b/connectcluster/connectcluster-connect-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "7Uvb_MbSk",
+    "name": "kubedb-kafka-connectcluster-connect",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/connectcluster/connectcluster-connect.json
+++ b/connectcluster/connectcluster-connect.json
@@ -2814,6 +2814,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Kafka / ConnectCluster / Connect",
-  "uid": "7Uvb_MbSk",
+  "uid": "kubedb-kafka-connectcluster-connect",
   "version": 1
 }

--- a/connectcluster/connectcluster-pod-perses.json
+++ b/connectcluster/connectcluster-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "DcPflMxIz",
+    "name": "kubedb-kafka-connectcluster-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/connectcluster/connectcluster-pod.json
+++ b/connectcluster/connectcluster-pod.json
@@ -3880,6 +3880,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Kafka / ConnectCluster / Pod",
-  "uid": "DcPflMxIz",
+  "uid": "kubedb-kafka-connectcluster-pod",
   "version": 1
 }

--- a/connectcluster/connectcluster-summary-perses.json
+++ b/connectcluster/connectcluster-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "lLHclMbIz",
+    "name": "kubedb-kafka-connectcluster-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/connectcluster/connectcluster-summary.json
+++ b/connectcluster/connectcluster-summary.json
@@ -2748,6 +2748,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Kafka / ConnectCluster / Summary",
-  "uid": "lLHclMbIz",
+  "uid": "kubedb-kafka-connectcluster-summary",
   "version": 1
 }

--- a/druid/druid_database_dashboard-perses.json
+++ b/druid/druid_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "i_yH4_xSk",
+    "name": "kubedb-druid-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/druid/druid_database_dashboard.json
+++ b/druid/druid_database_dashboard.json
@@ -1287,6 +1287,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Druid / Database",
-  "uid": "i_yH4_xSk",
+  "uid": "kubedb-druid-database",
   "version": 2
 }

--- a/druid/druid_pod_dashboard-perses.json
+++ b/druid/druid_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "5WZ_XCASk",
+    "name": "kubedb-druid-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/druid/druid_pod_dashboard.json
+++ b/druid/druid_pod_dashboard.json
@@ -862,6 +862,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Druid / Pod",
-  "uid": "5WZ_XCASk",
+  "uid": "kubedb-druid-pod",
   "version": 46
 }

--- a/druid/druid_summary_dashboard-perses.json
+++ b/druid/druid_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "druidSummary",
+    "name": "kubedb-druid-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/druid/druid_summary_dashboard.json
+++ b/druid/druid_summary_dashboard.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Druid / Summary",
-  "uid": "druidSummary",
+  "uid": "kubedb-druid-summary",
   "version": 7
 }

--- a/elasticsearch/elasticsearch_database_dashboard-perses.json
+++ b/elasticsearch/elasticsearch_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "0dBMIuN7k",
+    "name": "kubedb-elasticsearch-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/elasticsearch/elasticsearch_database_dashboard.json
+++ b/elasticsearch/elasticsearch_database_dashboard.json
@@ -2092,6 +2092,6 @@
   },
   "timezone": "utc",
   "title": "KubeDB / Elasticsearch / Database",
-  "uid": "0dBMIuN7k",
+  "uid": "kubedb-elasticsearch-database",
   "version": 4
 }

--- a/elasticsearch/elasticsearch_pod_dashboard-perses.json
+++ b/elasticsearch/elasticsearch_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "sjfsldk",
+    "name": "kubedb-elasticsearch-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/elasticsearch/elasticsearch_pod_dashboard.json
+++ b/elasticsearch/elasticsearch_pod_dashboard.json
@@ -2299,6 +2299,6 @@
   },
   "timezone": "utc",
   "title": "KubeDB / Elasticsearch / Pod",
-  "uid": "sjfsldk",
+  "uid": "kubedb-elasticsearch-pod",
   "version": 3
 }

--- a/elasticsearch/elasticsearch_summary_dashboard-perses.json
+++ b/elasticsearch/elasticsearch_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "72W2px6Vk",
+    "name": "kubedb-elasticsearch-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/elasticsearch/elasticsearch_summary_dashboard.json
@@ -3105,6 +3105,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Elasticsearch / Summary",
-  "uid": "72W2px6Vk",
+  "uid": "kubedb-elasticsearch-summary",
   "version": 5
 }

--- a/falco/app-level-events-perses.json
+++ b/falco/app-level-events-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "tf8LpYkSz",
+    "name": "ace-falco-appevents",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/falco/app-level-events.json
+++ b/falco/app-level-events.json
@@ -705,6 +705,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Falco / App Events",
-  "uid": "tf8LpYkSz",
+  "uid": "ace-falco-appevents",
   "version": 1
 }

--- a/falco/cluster-level-events-perses.json
+++ b/falco/cluster-level-events-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "TfCN3-f4k",
+    "name": "ace-falco-clusterevents",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/falco/cluster-level-events.json
+++ b/falco/cluster-level-events.json
@@ -343,6 +343,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Falco / Cluster Events",
-  "uid": "TfCN3-f4k",
+  "uid": "ace-falco-clusterevents",
   "version": 1
 }

--- a/falco/namespace-level-events-perses.json
+++ b/falco/namespace-level-events-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "sfTXBS-4z",
+    "name": "ace-falco-namespaceevents",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/falco/namespace-level-events.json
+++ b/falco/namespace-level-events.json
@@ -370,6 +370,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Falco / Namespace Events",
-  "uid": "sfTXBS-4z",
+  "uid": "ace-falco-namespaceevents",
   "version": 1
 }

--- a/falco/node-level-events-perses.json
+++ b/falco/node-level-events-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wACsNpzIz",
+    "name": "ace-falco-nodeevents",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/falco/node-level-events.json
+++ b/falco/node-level-events.json
@@ -371,6 +371,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Falco / Node Events",
-  "uid": "wACsNpzIz",
+  "uid": "ace-falco-nodeevents",
   "version": 2
 }

--- a/hanadb/hanadb_dashboard-perses.json
+++ b/hanadb/hanadb_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "EcC4JDFWz2",
+    "name": "kubedb-hanadb-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/hanadb/hanadb_dashboard.json
+++ b/hanadb/hanadb_dashboard.json
@@ -4432,6 +4432,6 @@
   },
   "timezone": "",
   "title": "KubeDB / HanaDB / Database",
-  "uid": "EcC4JDFWz2",
+  "uid": "kubedb-hanadb-database",
   "version": 1
 }

--- a/hanadb/hanadb_summary_dashboard-perses.json
+++ b/hanadb/hanadb_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "hanadb-summary",
+    "name": "kubedb-hanadb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/hanadb/hanadb_summary_dashboard.json
+++ b/hanadb/hanadb_summary_dashboard.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / HanaDB / Summary",
-  "uid": "hanadb-summary",
+  "uid": "kubedb-hanadb-summary",
   "version": 11
 }

--- a/hazelcast/hazelcast_database_dashboard-perses.json
+++ b/hazelcast/hazelcast_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "LrqJZlxHz",
+    "name": "kubedb-hazelcast-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/hazelcast/hazelcast_database_dashboard.json
+++ b/hazelcast/hazelcast_database_dashboard.json
@@ -1642,6 +1642,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Hazelcast / Database",
-  "uid": "LrqJZlxHz",
+  "uid": "kubedb-hazelcast-database",
   "version": 3
 }

--- a/hazelcast/hazelcast_pod_dashboard-perses.json
+++ b/hazelcast/hazelcast_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "hFvlarxHz",
+    "name": "kubedb-hazelcast-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/hazelcast/hazelcast_pod_dashboard.json
+++ b/hazelcast/hazelcast_pod_dashboard.json
@@ -1462,6 +1462,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Hazelcast / Pod",
-  "uid": "hFvlarxHz",
+  "uid": "kubedb-hazelcast-pod",
   "version": 2
 }

--- a/hazelcast/hazelcast_summary_dashboard-perses.json
+++ b/hazelcast/hazelcast_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-hazelcast-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/hazelcast/hazelcast_summary_dashboard.json
+++ b/hazelcast/hazelcast_summary_dashboard.json
@@ -3034,6 +3034,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Hazelcast / Summary",
-  "uid": "92M7QvyVk",
+  "uid": "kubedb-hazelcast-summary",
   "version": 2
 }

--- a/ignite/ignite_database_dashboard-perses.json
+++ b/ignite/ignite_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KTV2TJrGk2",
+    "name": "kubedb-ignite-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/ignite/ignite_database_dashboard.json
+++ b/ignite/ignite_database_dashboard.json
@@ -2160,6 +2160,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Ignite / Database",
-  "uid": "KTV2TJrGk2",
+  "uid": "kubedb-ignite-database",
   "version": 14
 }

--- a/ignite/ignite_pod_dashboard-perses.json
+++ b/ignite/ignite_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KTV2TJrGk2",
+    "name": "kubedb-ignite-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/ignite/ignite_pod_dashboard.json
+++ b/ignite/ignite_pod_dashboard.json
@@ -2088,6 +2088,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Ignite / Pod",
-  "uid": "KTV2TJrGk2",
+  "uid": "kubedb-ignite-pod",
   "version": 20
 }

--- a/ignite/ignite_summary_dashboard-perses.json
+++ b/ignite/ignite_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "04033bf3-5d6f-43c7-b5b4-07048acbdea2",
+    "name": "kubedb-ignite-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/ignite/ignite_summary_dashboard.json
+++ b/ignite/ignite_summary_dashboard.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Ignite / Summary",
-  "uid": "",
+  "uid": "kubedb-ignite-summary",
   "version": 1
 }

--- a/kafka/kafka_database_dashboard-perses.json
+++ b/kafka/kafka_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "CpTnxT0Sz",
+    "name": "kubedb-kafka-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/kafka/kafka_database_dashboard.json
+++ b/kafka/kafka_database_dashboard.json
@@ -2637,6 +2637,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Kafka / Database",
-  "uid": "CpTnxT0Sz",
+  "uid": "kubedb-kafka-database",
   "version": 57
 }

--- a/kafka/kafka_pod_dashboard-perses.json
+++ b/kafka/kafka_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "UwK-60AIk",
+    "name": "kubedb-kafka-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/kafka/kafka_pod_dashboard.json
+++ b/kafka/kafka_pod_dashboard.json
@@ -1726,6 +1726,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Kafka / Pod",
-  "uid": "UwK-60AIk",
+  "uid": "kubedb-kafka-pod",
   "version": 7
 }

--- a/kafka/kafka_summary-perses.json
+++ b/kafka/kafka_summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "kafkaSumMaRy",
+    "name": "kubedb-kafka-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/kafka/kafka_summary.json
+++ b/kafka/kafka_summary.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Kafka / Summary",
-  "uid": "kafkaSumMaRy",
+  "uid": "kubedb-kafka-summary",
   "version": 3
 }

--- a/kubestash/kubestash_dashboard-perses.json
+++ b/kubestash/kubestash_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "V7u2DqASk",
+    "name": "kubestash-dashboard",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/kubestash/kubestash_dashboard.json
+++ b/kubestash/kubestash_dashboard.json
@@ -2822,6 +2822,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeStash / Dashboard",
-  "uid": "V7u2DqASk",
+  "uid": "kubestash-dashboard",
   "version": 1
 }

--- a/kubevault/vaultserver_summary_dashboard-perses.json
+++ b/kubevault/vaultserver_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wzK8X8Nrd",
+    "name": "kubevault-vaultserver-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/kubevault/vaultserver_summary_dashboard.json
+++ b/kubevault/vaultserver_summary_dashboard.json
@@ -4165,6 +4165,6 @@
   },
   "timezone": "",
   "title": "KubeVault / VaultServer / Summary",
-  "uid": "wzK8X8Nrd",
+  "uid": "kubevault-vaultserver-summary",
   "version": 2
 }

--- a/mariadb/mariadb-database-perses.json
+++ b/mariadb/mariadb-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7z",
+    "name": "kubedb-mariadb-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mariadb/mariadb-database.json
+++ b/mariadb/mariadb-database.json
@@ -1483,6 +1483,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MariaDB / Database",
-  "uid": "ohrahgv7z",
+  "uid": "kubedb-mariadb-database",
   "version": 8
 }

--- a/mariadb/mariadb-galera-perses.json
+++ b/mariadb/mariadb-galera-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57k",
+    "name": "kubedb-mariadb-galera-cluster",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mariadb/mariadb-galera.json
+++ b/mariadb/mariadb-galera.json
@@ -595,6 +595,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MariaDB / Galera-Cluster",
-  "uid": "Zmva7c57k",
+  "uid": "kubedb-mariadb-galera-cluster",
   "version": 5
 }

--- a/mariadb/mariadb-pod-perses.json
+++ b/mariadb/mariadb-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-mariadb-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mariadb/mariadb-pod.json
+++ b/mariadb/mariadb-pod.json
@@ -3532,6 +3532,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MariaDB / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-mariadb-pod",
   "version": 3
 }

--- a/mariadb/mariadb-standard-replication-perses.json
+++ b/mariadb/mariadb-standard-replication-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57a",
+    "name": "kubedb-mariadb-standardreplication",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mariadb/mariadb-standard-replication.json
+++ b/mariadb/mariadb-standard-replication.json
@@ -1154,6 +1154,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MariaDB / Standard Replication",
-  "uid": "Zmva7c57a",
+  "uid": "kubedb-mariadb-standardreplication",
   "version": 72
 }

--- a/mariadb/mariadb-summary-perses.json
+++ b/mariadb/mariadb-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnk",
+    "name": "kubedb-mariadb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mariadb/mariadb-summary.json
+++ b/mariadb/mariadb-summary.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / MariaDB / Summary",
-  "uid": "VnOgk2Hnk",
+  "uid": "kubedb-mariadb-summary",
   "version": 11
 }

--- a/memcached/memcached_database_dashboard-perses.json
+++ b/memcached/memcached_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "AQxf3X-mk",
+    "name": "kubedb-memcached-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/memcached/memcached_database_dashboard.json
+++ b/memcached/memcached_database_dashboard.json
@@ -1373,6 +1373,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Memcached / Database",
-  "uid": "AQxf3X-mk",
+  "uid": "kubedb-memcached-database",
   "version": 25
 }

--- a/memcached/memcached_pod_dashboard-perses.json
+++ b/memcached/memcached_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "PpBVXkwZk",
+    "name": "kubedb-memcached-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/memcached/memcached_pod_dashboard.json
+++ b/memcached/memcached_pod_dashboard.json
@@ -1080,6 +1080,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Memcached / Pod",
-  "uid": "PpBVXkwZk",
+  "uid": "kubedb-memcached-pod",
   "version": 4
 }

--- a/memcached/memcached_summary_dashboard-perses.json
+++ b/memcached/memcached_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnk",
+    "name": "kubedb-memcached-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/memcached/memcached_summary_dashboard.json
+++ b/memcached/memcached_summary_dashboard.json
@@ -2400,6 +2400,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Memcached / Summary",
-  "uid": "VnOgk2Hnk",
+  "uid": "kubedb-memcached-summary",
   "version": 3
 }

--- a/milvus/milvus-database-perses.json
+++ b/milvus/milvus-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "uLf5cJ3Gz",
+    "name": "kubedb-milvus-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/milvus/milvus-database.json
+++ b/milvus/milvus-database.json
@@ -10877,6 +10877,6 @@
   },
   "timezone": "browser",
   "title": "KubeDB / Milvus / Database",
-  "uid": "uLf5cJ3Gz",
+  "uid": "kubedb-milvus-database",
   "version": 18
 }

--- a/milvus/milvus-summary-perses.json
+++ b/milvus/milvus-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "milvusSumMaRyl",
+    "name": "kubedb-milvus-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/milvus/milvus-summary.json
+++ b/milvus/milvus-summary.json
@@ -2925,6 +2925,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Milvus / Summary",
-  "uid": "milvusSumMaRyl",
+  "uid": "kubedb-milvus-summary",
   "version": 2
 }

--- a/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "a4297874-8642-4b55-9012-8864e683e3db",
+    "name": "kubedb-mongodb-database-replicaset-legacy",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mongodb/legacy/mongodb-pod-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-pod-dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "e0877202-8b74-47c9-86f0-472e495ac99a",
+    "name": "kubedb-mongodb-pod-legacy",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mongodb/legacy/mongodb-summary-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-summary-dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "5ed3c475-b6c3-46e6-aeba-88921918bf7c",
+    "name": "kubedb-mongodb-summary-legacy",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mongodb/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/mongodb-database-replset-dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "d0259b78-49c0-4614-bb8b-2ed302a5a8ec",
+    "name": "kubedb-mongodb-database-replicaset",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mongodb/mongodb-pod-dashboard-perses.json
+++ b/mongodb/mongodb-pod-dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "e63d0da5-722a-4e00-aa0e-c25ee5d8cea4",
+    "name": "kubedb-mongodb-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mongodb/mongodb-summary-dashboard-perses.json
+++ b/mongodb/mongodb-summary-dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-mongodb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mongodb/mongodb-summary-dashboard.json
+++ b/mongodb/mongodb-summary-dashboard.json
@@ -3010,6 +3010,6 @@
   },
   "timezone": "",
   "title": "KubeDB / MongoDB / Summary",
-  "uid": "92M7QvyVk",
+  "uid": "kubedb-mongodb-summary",
   "version": 1
 }

--- a/mssqlserver/mssqlserver_database_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-mssqlserver-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mssqlserver/mssqlserver_database_dashboard.json
+++ b/mssqlserver/mssqlserver_database_dashboard.json
@@ -1271,6 +1271,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MSSQLServer / Database",
-  "uid": "ohrahgv7T",
+  "uid": "kubedb-mssqlserver-database",
   "version": 37
 }

--- a/mssqlserver/mssqlserver_pod_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "9J6ObCEMz",
+    "name": "kubedb-mssqlserver-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/mssqlserver/mssqlserver_pod_dashboard.json
@@ -1979,6 +1979,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MSSQLServer / Pod",
-  "uid": "9J6ObCEMz",
+  "uid": "kubedb-mssqlserver-pod",
   "version": 8
 }

--- a/mssqlserver/mssqlserver_summary_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "qDMhbh0Iz",
+    "name": "kubedb-mssqlserver-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mssqlserver/mssqlserver_summary_dashboard.json
+++ b/mssqlserver/mssqlserver_summary_dashboard.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / MSSQLServer / Summary",
-  "uid": "qDMhbh0Iz",
+  "uid": "kubedb-mssqlserver-summary",
   "version": 9
 }

--- a/mysql/mysql_database_dashboard-perses.json
+++ b/mysql/mysql_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-mysql-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mysql/mysql_database_dashboard.json
+++ b/mysql/mysql_database_dashboard.json
@@ -1313,6 +1313,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MySQL / Database",
-  "uid": "ohrahgv7T",
+  "uid": "kubedb-mysql-database",
   "version": 2
 }

--- a/mysql/mysql_group_replication-perses.json
+++ b/mysql/mysql_group_replication-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57k",
+    "name": "kubedb-mysql-group-replication-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mysql/mysql_group_replication.json
+++ b/mysql/mysql_group_replication.json
@@ -1623,6 +1623,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MySQL / Group-Replication-Summary",
-  "uid": "Zmva7c57k",
+  "uid": "kubedb-mysql-group-replication-summary",
   "version": 2
 }

--- a/mysql/mysql_pod_dashboard-perses.json
+++ b/mysql/mysql_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-mysql-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mysql/mysql_pod_dashboard.json
+++ b/mysql/mysql_pod_dashboard.json
@@ -3531,6 +3531,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / MySQL / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-mysql-pod",
   "version": 6
 }

--- a/mysql/mysql_summary_dashboard-perses.json
+++ b/mysql/mysql_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2Hnk",
+    "name": "kubedb-mysql-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/mysql/mysql_summary_dashboard.json
+++ b/mysql/mysql_summary_dashboard.json
@@ -3036,6 +3036,6 @@
   },
   "timezone": "",
   "title": "KubeDB / MySQL / Summary",
-  "uid": "VsnOgk2Hnk",
+  "uid": "kubedb-mysql-summary",
   "version": 3
 }

--- a/neo4j/neo4j-database-perses.json
+++ b/neo4j/neo4j-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fifRHuGDz",
+    "name": "kubedb-neo4j-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/neo4j/neo4j-database.json
+++ b/neo4j/neo4j-database.json
@@ -2997,6 +2997,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Neo4j / Database",
-  "uid": "fifRHuGDz",
+  "uid": "kubedb-neo4j-database",
   "version": 29
 }

--- a/neo4j/neo4j-pod-perses.json
+++ b/neo4j/neo4j-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fifRHuGDz",
+    "name": "kubedb-neo4j-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/neo4j/neo4j-pod.json
+++ b/neo4j/neo4j-pod.json
@@ -3341,6 +3341,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Neo4j / Pod",
-  "uid": "fifRHuGDz",
+  "uid": "kubedb-neo4j-pod",
   "version": 28
 }

--- a/neo4j/neo4j-summary-perses.json
+++ b/neo4j/neo4j-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "neo4jSumMaRy",
+    "name": "kubedb-neo4j-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/neo4j/neo4j-summary.json
+++ b/neo4j/neo4j-summary.json
@@ -2920,6 +2920,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Neo4j / Summary",
-  "uid": "neo4jSumMaRy",
+  "uid": "kubedb-neo4j-summary",
   "version": 5
 }

--- a/oracle/oracle_database_dashboard-perses.json
+++ b/oracle/oracle_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-oracle-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/oracle/oracle_database_dashboard.json
+++ b/oracle/oracle_database_dashboard.json
@@ -1285,6 +1285,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Oracle / Database",
-  "uid": "ohrahgv7T",
+  "uid": "kubedb-oracle-database",
   "version": 11
 }

--- a/oracle/oracle_pod_dashboard-perses.json
+++ b/oracle/oracle_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "9J6ObCEMz",
+    "name": "kubedb-oracle-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/oracle/oracle_pod_dashboard.json
+++ b/oracle/oracle_pod_dashboard.json
@@ -1631,6 +1631,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Oracle / Pod",
-  "uid": "9J6ObCEMz",
+  "uid": "kubedb-oracle-pod",
   "version": 5
 }

--- a/oracle/oracle_summary_dashboard-perses.json
+++ b/oracle/oracle_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-oracle-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/oracle/oracle_summary_dashboard.json
+++ b/oracle/oracle_summary_dashboard.json
@@ -3011,6 +3011,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Oracle / Summary",
-  "uid": "92M7QvyVk",
+  "uid": "kubedb-oracle-summary",
   "version": 4
 }

--- a/perconaxtradb/perconaxtradb-database-perses.json
+++ b/perconaxtradb/perconaxtradb-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7z",
+    "name": "kubedb-perconaxtradb-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/perconaxtradb/perconaxtradb-database.json
+++ b/perconaxtradb/perconaxtradb-database.json
@@ -1483,6 +1483,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / PerconaXtraDB / Database",
-  "uid": "ohrahgv7z",
+  "uid": "kubedb-perconaxtradb-database",
   "version": 8
 }

--- a/perconaxtradb/perconaxtradb-galera-perses.json
+++ b/perconaxtradb/perconaxtradb-galera-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57k",
+    "name": "kubedb-perconaxtradb-galera-cluster",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/perconaxtradb/perconaxtradb-galera.json
+++ b/perconaxtradb/perconaxtradb-galera.json
@@ -595,6 +595,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / PerconaXtraDB / Galera-Cluster",
-  "uid": "Zmva7c57k",
+  "uid": "kubedb-perconaxtradb-galera-cluster",
   "version": 5
 }

--- a/perconaxtradb/perconaxtradb-pod-perses.json
+++ b/perconaxtradb/perconaxtradb-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-perconaxtradb-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/perconaxtradb/perconaxtradb-pod.json
+++ b/perconaxtradb/perconaxtradb-pod.json
@@ -3532,6 +3532,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / PerconaXtraDB / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-perconaxtradb-pod",
   "version": 3
 }

--- a/perconaxtradb/perconaxtradb-summary-perses.json
+++ b/perconaxtradb/perconaxtradb-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnkx",
+    "name": "kubedb-perconaxtradb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/perconaxtradb/perconaxtradb-summary.json
+++ b/perconaxtradb/perconaxtradb-summary.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / PerconaXtraDB / Summary",
-  "uid": "VnOgk2Hnkx",
+  "uid": "kubedb-perconaxtradb-summary",
   "version": 2
 }

--- a/pgbouncer/pgbouncer_database-perses.json
+++ b/pgbouncer/pgbouncer_database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KN5pOCn4g",
+    "name": "kubedb-pgbouncer-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/pgbouncer/pgbouncer_database.json
+++ b/pgbouncer/pgbouncer_database.json
@@ -1120,6 +1120,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / PgBouncer / Database",
-  "uid": "KN5pOCn4g",
+  "uid": "kubedb-pgbouncer-database",
   "version": 11
 }

--- a/pgbouncer/pgbouncer_pod-perses.json
+++ b/pgbouncer/pgbouncer_pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-pgbouncer-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/pgbouncer/pgbouncer_pod.json
+++ b/pgbouncer/pgbouncer_pod.json
@@ -1061,6 +1061,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / PgBouncer / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-pgbouncer-pod",
   "version": 2
 }

--- a/pgbouncer/pgbouncer_summary-perses.json
+++ b/pgbouncer/pgbouncer_summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2212Hnk",
+    "name": "kubedb-pgbouncer-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/pgbouncer/pgbouncer_summary.json
+++ b/pgbouncer/pgbouncer_summary.json
@@ -2405,6 +2405,6 @@
   },
   "timezone": "",
   "title": "KubeDB / PgBouncer / Summary",
-  "uid": "VsnOgk2212Hnk",
+  "uid": "kubedb-pgbouncer-summary",
   "version": 1
 }

--- a/pgpool/pgpool_database-perses.json
+++ b/pgpool/pgpool_database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KN5pOCn4g",
+    "name": "kubedb-pgpool-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/pgpool/pgpool_database.json
+++ b/pgpool/pgpool_database.json
@@ -2745,6 +2745,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Pgpool / Database",
-  "uid": "KN5pOCn4g",
+  "uid": "kubedb-pgpool-database",
   "version": 3
 }

--- a/pgpool/pgpool_pod-perses.json
+++ b/pgpool/pgpool_pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-pgpool-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/pgpool/pgpool_pod.json
+++ b/pgpool/pgpool_pod.json
@@ -1062,6 +1062,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Pgpool / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-pgpool-pod",
   "version": 2
 }

--- a/pgpool/pgpool_summary-perses.json
+++ b/pgpool/pgpool_summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2212Hnk",
+    "name": "kubedb-pgpool-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/pgpool/pgpool_summary.json
+++ b/pgpool/pgpool_summary.json
@@ -2405,6 +2405,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Pgpool / Summary",
-  "uid": "VsnOgk2212Hnk",
+  "uid": "kubedb-pgpool-summary",
   "version": 1
 }

--- a/policy/cluster-violations-perses.json
+++ b/policy/cluster-violations-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "TWCN3-f4k",
+    "name": "ace-policy-clusterviolations",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/policy/cluster-violations.json
+++ b/policy/cluster-violations.json
@@ -274,6 +274,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Policy / Cluster Violations",
-  "uid": "TWCN3-f4k",
+  "uid": "ace-policy-clusterviolations",
   "version": 2
 }

--- a/policy/namespace-violations-perses.json
+++ b/policy/namespace-violations-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "stTXBS-4z",
+    "name": "ace-policy-namespaceviolations",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/policy/namespace-violations.json
+++ b/policy/namespace-violations.json
@@ -304,6 +304,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Policy / Namespace Violations",
-  "uid": "stTXBS-4z",
+  "uid": "ace-policy-namespaceviolations",
   "version": 2
 }

--- a/postgres/postgres_databases_dashboard-perses.json
+++ b/postgres/postgres_databases_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "6v_W_NNn_kl",
+    "name": "kubedb-postgres-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/postgres/postgres_databases_dashboard.json
+++ b/postgres/postgres_databases_dashboard.json
@@ -1930,6 +1930,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Postgres / Database",
-  "uid": "6v_W_NNn_kl",
+  "uid": "kubedb-postgres-database",
   "version": 2
 }

--- a/postgres/postgres_pods_dashboard-perses.json
+++ b/postgres/postgres_pods_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "IgXOThN7ztest",
+    "name": "kubedb-postgres-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/postgres/postgres_pods_dashboard.json
+++ b/postgres/postgres_pods_dashboard.json
@@ -1685,7 +1685,7 @@
   },
   "timezone": "",
   "title": "KubeDB / Postgres / Pod",
-  "uid": "IgXOThN7ztest",
+  "uid": "kubedb-postgres-pod",
   "version": 2
 }
 

--- a/postgres/postgres_summary_dashboard-perses.json
+++ b/postgres/postgres_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnky",
+    "name": "kubedb-postgres-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/postgres/postgres_summary_dashboard.json
+++ b/postgres/postgres_summary_dashboard.json
@@ -3519,7 +3519,7 @@
   },
   "timezone": "",
   "title": "KubeDB / Postgres / Summary",
-  "uid": "VnOgk2Hnky",
+  "uid": "kubedb-postgres-summary",
   "version": 2
 }
 

--- a/proxysql/proxysql-database-perses.json
+++ b/proxysql/proxysql-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-proxysql-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/proxysql/proxysql-database.json
+++ b/proxysql/proxysql-database.json
@@ -7806,6 +7806,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / ProxySQL / Database",
-  "uid": "ohrahgv7T",
+  "uid": "kubedb-proxysql-database",
   "version": 10
 }

--- a/proxysql/proxysql-pod-perses.json
+++ b/proxysql/proxysql-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-proxysql-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/proxysql/proxysql-pod.json
+++ b/proxysql/proxysql-pod.json
@@ -1337,6 +1337,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / ProxySQL / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-proxysql-pod",
   "version": 9
 }

--- a/proxysql/proxysql-summary-perses.json
+++ b/proxysql/proxysql-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2Hnk",
+    "name": "kubedb-proxysql-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/proxysql/proxysql-summary.json
+++ b/proxysql/proxysql-summary.json
@@ -2404,6 +2404,6 @@
     },
     "timezone": "",
     "title": "KubeDB / ProxySQL / Summary",
-    "uid": "VsnOgk2Hnk",
+    "uid": "kubedb-proxysql-summary",
     "version": 9
   }

--- a/qdrant/qdrant_database_dashboard-perses.json
+++ b/qdrant/qdrant_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "891d29ac-3a28-4b09-8628-a2559963ed4a",
+    "name": "kubedb-qdrant-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/qdrant/qdrant_pod_dashboard-perses.json
+++ b/qdrant/qdrant_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fd868f7d-b1ee-4a46-8cd4-524d08ef710b",
+    "name": "kubedb-qdrant-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/qdrant/qdrant_summary_dashboard-perses.json
+++ b/qdrant/qdrant_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "60777403-b8d8-45e8-b9ca-0ed3c35b86e7",
+    "name": "kubedb-qdrant-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/rabbitmq/rabbitmq-database-perses.json
+++ b/rabbitmq/rabbitmq-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrdrabbitmq",
+    "name": "kubedb-rabbitmq-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/rabbitmq/rabbitmq-database.json
+++ b/rabbitmq/rabbitmq-database.json
@@ -18017,6 +18017,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / RabbitMQ / Database",
-  "uid": "ohrdrabbitmq",
+  "uid": "kubedb-rabbitmq-database",
   "version": 4
 }

--- a/rabbitmq/rabbitmq-pod-perses.json
+++ b/rabbitmq/rabbitmq-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-rabbitmq-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/rabbitmq/rabbitmq-pod.json
+++ b/rabbitmq/rabbitmq-pod.json
@@ -1535,6 +1535,6 @@
   },
   "timezone": "",
   "title": "KubeDB / RabbitMQ / Pod",
-  "uid": "FktZiiOnz",
+  "uid": "kubedb-rabbitmq-pod",
   "version": 27
 }

--- a/rabbitmq/rabbitmq-summary-perses.json
+++ b/rabbitmq/rabbitmq-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "rAbbItMqSumMaRy",
+    "name": "kubedb-rabbitmq-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/rabbitmq/rabbitmq-summary.json
+++ b/rabbitmq/rabbitmq-summary.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / RabbitMQ / Summary",
-  "uid": "rAbbItMqSumMaRy",
+  "uid": "kubedb-rabbitmq-summary",
   "version": 1
 }

--- a/redis/redis_pod_dashboard-perses.json
+++ b/redis/redis_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fF-N4cH7k",
+    "name": "kubedb-redis-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/redis/redis_pod_dashboard.json
+++ b/redis/redis_pod_dashboard.json
@@ -1803,6 +1803,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Redis / Pod",
-  "uid": "fF-N4cH7k",
+  "uid": "kubedb-redis-pod",
   "version": 5
 }

--- a/redis/redis_shards_dashboard-perses.json
+++ b/redis/redis_shards_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fF-N4cHsh",
+    "name": "kubedb-redis-shard",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/redis/redis_shards_dashboard.json
+++ b/redis/redis_shards_dashboard.json
@@ -832,6 +832,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Redis / Shard",
-  "uid": "fF-N4cHsh",
+  "uid": "kubedb-redis-shard",
   "version": 2
 }

--- a/redis/redis_summary_dashboard-perses.json
+++ b/redis/redis_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wzK8X8Nrd",
+    "name": "kubedb-redis-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/redis/redis_summary_dashboard.json
+++ b/redis/redis_summary_dashboard.json
@@ -3438,6 +3438,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Redis / Summary",
-  "uid": "wzK8X8Nrd",
+  "uid": "kubedb-redis-summary",
   "version": 9
 }

--- a/redis/sentinel_pod_dashboard-perses.json
+++ b/redis/sentinel_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fF-N4cH7k",
+    "name": "kubedb-redissentinel-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/redis/sentinel_pod_dashboard.json
+++ b/redis/sentinel_pod_dashboard.json
@@ -1087,6 +1087,6 @@
   },
   "timezone": "utc",
   "title": "KubeDB / RedisSentinel / Pod",
-  "uid": "fF-N4cH7k",
+  "uid": "kubedb-redissentinel-pod",
   "version": 1
 }

--- a/redis/sentinel_summary_dashbaord-perses.json
+++ b/redis/sentinel_summary_dashbaord-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wzK8X8Nrd",
+    "name": "kubedb-redissentinel-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/redis/sentinel_summary_dashbaord.json
+++ b/redis/sentinel_summary_dashbaord.json
@@ -3106,6 +3106,6 @@
   },
   "timezone": "",
   "title": "KubeDB / RedisSentinel / Summary",
-  "uid": "wzK8X8Nrd",
+  "uid": "kubedb-redissentinel-summary",
   "version": 3
 }

--- a/scanner/app-level-cves-perses.json
+++ b/scanner/app-level-cves-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Egwi40hVz",
+    "name": "ace-scanner-appcves",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/scanner/app-level-cves.json
+++ b/scanner/app-level-cves.json
@@ -377,6 +377,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Scanner / App CVEs",
-  "uid": "Egwi40hVz",
+  "uid": "ace-scanner-appcves",
   "version": 2
 }

--- a/scanner/cluster-level-cves-perses.json
+++ b/scanner/cluster-level-cves-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wqK6M0h4k",
+    "name": "ace-scanner-clustercves",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/scanner/cluster-level-cves.json
+++ b/scanner/cluster-level-cves.json
@@ -256,6 +256,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Scanner / Cluster CVEs",
-  "uid": "wqK6M0h4k",
+  "uid": "ace-scanner-clustercves",
   "version": 2
 }

--- a/scanner/cve-details-perses.json
+++ b/scanner/cve-details-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "v87d4024k",
+    "name": "ace-scanner-cvereport",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/scanner/cve-details.json
+++ b/scanner/cve-details.json
@@ -288,6 +288,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Scanner / CVE Report",
-  "uid": "v87d4024k",
+  "uid": "ace-scanner-cvereport",
   "version": 1
 }

--- a/scanner/image-level-cves-perses.json
+++ b/scanner/image-level-cves-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "JAqfn0h4k",
+    "name": "ace-scanner-imagecves",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/scanner/image-level-cves.json
+++ b/scanner/image-level-cves.json
@@ -288,6 +288,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Scanner / Image CVEs",
-  "uid": "JAqfn0h4k",
+  "uid": "ace-scanner-imagecves",
   "version": 1
 }

--- a/scanner/namespace-level-cves-perses.json
+++ b/scanner/namespace-level-cves-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Edocn0hVz",
+    "name": "ace-scanner-namespacecves",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/scanner/namespace-level-cves.json
+++ b/scanner/namespace-level-cves.json
@@ -287,6 +287,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "ACE / Scanner / Namespace CVEs",
-  "uid": "Edocn0hVz",
+  "uid": "ace-scanner-namespacecves",
   "version": 2
 }

--- a/singlestore/singlestore_database_dashboard-perses.json
+++ b/singlestore/singlestore_database_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "_HMhxhASz",
+    "name": "kubedb-singlestore-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/singlestore/singlestore_database_dashboard.json
+++ b/singlestore/singlestore_database_dashboard.json
@@ -1077,6 +1077,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Singlestore / Database",
-  "uid": "_HMhxhASz",
+  "uid": "kubedb-singlestore-database",
   "version": 2
 }

--- a/singlestore/singlestore_pod_dashboard-perses.json
+++ b/singlestore/singlestore_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "cvGhb2ASk",
+    "name": "kubedb-singlestore-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/singlestore/singlestore_pod_dashboard.json
+++ b/singlestore/singlestore_pod_dashboard.json
@@ -2637,6 +2637,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Singlestore / Pod",
-  "uid": "cvGhb2ASk",
+  "uid": "kubedb-singlestore-pod",
   "version": 1
 }

--- a/singlestore/singlestore_summary_dashboard-perses.json
+++ b/singlestore/singlestore_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "qDMhbh0Iz",
+    "name": "kubedb-singlestore-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/singlestore/singlestore_summary_dashboard.json
+++ b/singlestore/singlestore_summary_dashboard.json
@@ -2953,6 +2953,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Singlestore / Summary",
-  "uid": "qDMhbh0Iz",
+  "uid": "kubedb-singlestore-summary",
   "version": 2
 }

--- a/solr/solr-database-perses.json
+++ b/solr/solr-database-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Vm64KR1Sz",
+    "name": "kubedb-solr-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/solr/solr-database.json
+++ b/solr/solr-database.json
@@ -3445,6 +3445,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "KubeDB / Solr / Database",
-  "uid": "Vm64KR1Sz",
+  "uid": "kubedb-solr-database",
   "version": 3
 }

--- a/solr/solr-pod-perses.json
+++ b/solr/solr-pod-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "0dBMIuN7m",
+    "name": "kubedb-solr-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/solr/solr-pod.json
+++ b/solr/solr-pod.json
@@ -7084,6 +7084,6 @@
     },
     "timezone": "utc",
     "title": "KubeDB / Solr / Pod",
-    "uid": "0dBMIuN7m",
+    "uid": "kubedb-solr-pod",
     "version": 21
   }

--- a/solr/solr-summary-perses.json
+++ b/solr/solr-summary-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-solr-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/solr/solr-summary.json
+++ b/solr/solr-summary.json
@@ -3033,6 +3033,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Solr / Summary",
-  "uid": "92M7QvyVk",
+  "uid": "kubedb-solr-summary",
   "version": 2
 }

--- a/stash/stash_dashboard-perses.json
+++ b/stash/stash_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "NHbytwI7z",
+    "name": "stash-dashboard",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/stash/stash_dashboard.json
+++ b/stash/stash_dashboard.json
@@ -2893,6 +2893,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Stash / Dashboard",
-  "uid": "NHbytwI7z",
+  "uid": "stash-dashboard",
   "version": 6
 }

--- a/stash/stash_dashboard_legacy-perses.json
+++ b/stash/stash_dashboard_legacy-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "NHbytwI7z",
+    "name": "stash-dashboard-legacy",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/stash/stash_dashboard_legacy.json
+++ b/stash/stash_dashboard_legacy.json
@@ -2893,6 +2893,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Stash / Dashboard",
-  "uid": "NHbytwI7z",
+  "uid": "stash-dashboard-legacy",
   "version": 6
 }

--- a/weaviate/weaviate_summary_dashboard.json
+++ b/weaviate/weaviate_summary_dashboard.json
@@ -2968,6 +2968,6 @@
   },
   "timezone": "",
   "title": "KubeDB / Weaviate / Summary",
-  "uid": "Jste6jfDz",
+  "uid": "kubedb-weaviate-summary",
   "version": 6
 }

--- a/zookeeper/zookeeper_ensemble_dashboard-perses.json
+++ b/zookeeper/zookeeper_ensemble_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "a1W-SoASk",
+    "name": "kubedb-zookeeper-ensemble",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/zookeeper/zookeeper_ensemble_dashboard.json
+++ b/zookeeper/zookeeper_ensemble_dashboard.json
@@ -9454,6 +9454,6 @@
   },
   "timezone": "",
   "title": "KubeDB / ZooKeeper / Ensemble",
-  "uid": "a1W-SoASk",
+  "uid": "kubedb-zookeeper-ensemble",
   "version": 2
 }

--- a/zookeeper/zookeeper_pod_dashboard-perses.json
+++ b/zookeeper/zookeeper_pod_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "NBKKAJAIz",
+    "name": "kubedb-zookeeper-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/zookeeper/zookeeper_pod_dashboard.json
+++ b/zookeeper/zookeeper_pod_dashboard.json
@@ -10022,6 +10022,6 @@
   },
   "timezone": "",
   "title": "KubeDB / ZooKeeper / Pod",
-  "uid": "NBKKAJAIz",
+  "uid": "kubedb-zookeeper-pod",
   "version": 1
 }

--- a/zookeeper/zookeeper_summary_dashboard-perses.json
+++ b/zookeeper/zookeeper_summary_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Vj9GtJ0Iz",
+    "name": "kubedb-zookeeper-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/zookeeper/zookeeper_summary_dashboard.json
+++ b/zookeeper/zookeeper_summary_dashboard.json
@@ -3100,6 +3100,6 @@
   },
   "timezone": "",
   "title": "KubeDB / ZooKeeper / Summary",
-  "uid": "Vj9GtJ0Iz",
+  "uid": "kubedb-zookeeper-summary",
   "version": 3
 }


### PR DESCRIPTION
## Problem
`percli migrate` copies a Grafana dashboard's `uid` verbatim into the Perses `metadata.name`, which the operator surfaces as `.status.dashboard.id`. The source carried duplicate/opaque uids across distinct dashboards, so their migrated Perses dashboards collided on the same dashboard (scoped only by project + folder) — last writer wins. 16 groups were affected.

## Fix
Set a deterministic, self-documenting identity everywhere:
- `metadata.name` in all **106** `*-perses.json`
- `uid` in the Grafana originals (**100** files + one empty-uid fix)

…to `normalize(display/title)` = `kubedb-<db>-<type>` (lower, strip spaces, split `/`, join `-`), with a `-legacy` suffix for `legacy/*` variants that share a display name with their current counterpart.

Left as-is: 8 mongodb/qdrant originals with no top-level `uid` (Grafana auto-assigns; their `-perses.json` names are fixed), and 2 weaviate originals already on this convention.

## Verification
- Zero duplicate string-uids remain; the 106 perses names are unique.
- Paired with the `opnpulse/perses-dashboards` generator patch (fixups67.py) that sets `metadata.name = normalize(display.name)` post-migration, so re-running the pipeline reproduces these names regardless of source uid.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/dashboards/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787372650&installation_model_id=19678&pr_number=109&repository=opnpulse%2Fdashboards&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Fdashboards%2Fpull%2F109&signature=e8ed682b86dac46010b07044ecda278be976cf3d8086235d6353259479fafa36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->