### PR TITLE
Use kube_namespace_status_phase for namespace variables

### DIFF
--- a/hanadb/hanadb_summary_dashboard-perses.json
+++ b/hanadb/hanadb_summary_dashboard-perses.json
@@ -47,7 +47,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_created"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/hanadb/hanadb_summary_dashboard.json
+++ b/hanadb/hanadb_summary_dashboard.json
@@ -2866,7 +2866,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2876,7 +2876,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/kubestash/kubestash_dashboard-perses.json
+++ b/kubestash/kubestash_dashboard-perses.json
@@ -49,7 +49,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "core_kubestash_com_backupconfiguration_created"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/kubestash/kubestash_dashboard.json
+++ b/kubestash/kubestash_dashboard.json
@@ -2641,7 +2641,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(core_kubestash_com_backupconfiguration_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": "List of namespaces where the backups are running",
         "error": null,
         "hide": 0,
@@ -2651,7 +2651,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(core_kubestash_com_backupconfiguration_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/milvus/milvus-database-perses.json
+++ b/milvus/milvus-database-perses.json
@@ -46,7 +46,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_pod_info"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/milvus/milvus-database.json
+++ b/milvus/milvus-database.json
@@ -10406,7 +10406,7 @@
           "value": "kubedb"
         },
         "datasource": null,
-        "definition": "label_values(kube_pod_info, namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -10416,7 +10416,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_pod_info, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/milvus/milvus-summary-perses.json
+++ b/milvus/milvus-summary-perses.json
@@ -47,7 +47,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_created"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/milvus/milvus-summary.json
+++ b/milvus/milvus-summary.json
@@ -2834,7 +2834,7 @@
           "value": "kubedb"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2844,7 +2844,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 1,

--- a/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
@@ -78,7 +78,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_labels"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/mongodb/legacy/mongodb-database-replset-dashboard.json
+++ b/mongodb/legacy/mongodb-database-replset-dashboard.json
@@ -1258,7 +1258,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_labels,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1267,7 +1267,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_labels,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mongodb/legacy/mongodb-pod-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-pod-dashboard-perses.json
@@ -78,7 +78,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_labels"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/mongodb/legacy/mongodb-pod-dashboard.json
+++ b/mongodb/legacy/mongodb-pod-dashboard.json
@@ -1817,7 +1817,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_labels,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1826,7 +1826,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_labels,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mongodb/legacy/mongodb-summary-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-summary-dashboard-perses.json
@@ -47,7 +47,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_labels"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/mongodb/legacy/mongodb-summary-dashboard.json
+++ b/mongodb/legacy/mongodb-summary-dashboard.json
@@ -2630,7 +2630,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_labels,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2639,7 +2639,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(kube_namespace_labels,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/mssqlserver/mssqlserver_pod_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_pod_dashboard-perses.json
@@ -90,7 +90,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "up{target=\"mssqlserver_database\"}"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/mssqlserver/mssqlserver_pod_dashboard.json
@@ -1885,7 +1885,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(up{target=\"mssqlserver_database\"}, namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1895,7 +1895,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(up{target=\"mssqlserver_database\"}, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/redis/redis_pod_dashboard-perses.json
+++ b/redis/redis_pod_dashboard-perses.json
@@ -46,7 +46,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "redis_up"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/redis/redis_pod_dashboard.json
+++ b/redis/redis_pod_dashboard.json
@@ -1685,7 +1685,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(redis_up, namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -1695,7 +1695,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(redis_up, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,

--- a/redis/redis_shards_dashboard-perses.json
+++ b/redis/redis_shards_dashboard-perses.json
@@ -46,7 +46,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "redis_up"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/redis/redis_shards_dashboard.json
+++ b/redis/redis_shards_dashboard.json
@@ -703,7 +703,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(redis_up, namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -713,7 +713,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(redis_up, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,

--- a/redis/sentinel_pod_dashboard-perses.json
+++ b/redis/sentinel_pod_dashboard-perses.json
@@ -46,7 +46,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "redis_up"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/redis/sentinel_pod_dashboard.json
+++ b/redis/sentinel_pod_dashboard.json
@@ -969,7 +969,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(redis_up, namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -979,7 +979,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(redis_up, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "refresh": 2,

--- a/stash/stash_dashboard-perses.json
+++ b/stash/stash_dashboard-perses.json
@@ -49,7 +49,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "stash_appscode_com_backupconfiguration_info"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/stash/stash_dashboard.json
+++ b/stash/stash_dashboard.json
@@ -2724,7 +2724,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(stash_appscode_com_backupconfiguration_info,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": "List of namespaces where the backups are running",
         "error": null,
         "hide": 0,
@@ -2733,7 +2733,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(stash_appscode_com_backupconfiguration_info,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,

--- a/stash/stash_dashboard_legacy-perses.json
+++ b/stash/stash_dashboard_legacy-perses.json
@@ -49,7 +49,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "stash_appscode_com_backupconfiguration_info"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/stash/stash_dashboard_legacy.json
+++ b/stash/stash_dashboard_legacy.json
@@ -2724,7 +2724,7 @@
           "value": "$__all"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(stash_appscode_com_backupconfiguration_info,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": "List of namespaces where the backups are running",
         "error": null,
         "hide": 0,
@@ -2733,7 +2733,7 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "label_values(stash_appscode_com_backupconfiguration_info,namespace)",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
Standardizes the `namespace` variable across all Grafana and Perses dashboards on `kube_namespace_status_phase{phase="Active"}`, matching the 78 Grafana / 74 Perses dashboards that already used it.

- Grafana: `label_values(kube_namespace_status_phase{phase="Active"},namespace)` (both `definition` and `query` where both exist)
- Perses: `matchers: ["kube_namespace_status_phase{phase=\"Active\"}"]`

13 dashboards, fixed symmetrically in both formats (26 files):

| was | dashboards |
|---|---|
| `redis_up` | redis pod, redis shards, sentinel pod |
| `kube_namespace_labels` | mongodb/legacy database-replset, pod, summary |
| `stash_appscode_com_backupconfiguration_info` | stash, stash legacy |
| `kube_namespace_created` | milvus summary, hanadb summary |
| `kube_pod_info` | milvus database |
| `core_kubestash_com_backupconfiguration_created` | kubestash |
| `up{target="mssqlserver_database"}` | mssqlserver pod |

The mssqlserver matcher was additionally a typo — no series carries `target="mssqlserver_database"`; the exporter emits `target="mssql_database"`. Verified against a live cluster: `up{target="mssql_database"}` returns 5 series, the old spelling returns none.

## Behavior change

This widens the namespace dropdown. Matchers like `redis_up` and `stash_appscode_com_backupconfiguration_info` restricted it to namespaces that actually had the relevant workload; `kube_namespace_status_phase{phase="Active"}` lists every active namespace (23 on the cluster I checked), so a user can now select a namespace with no Redis/backup and get empty panels. That is the behavior every already-conforming dashboard has, but it is a real loss of filtering for the stash/kubestash dashboards in particular — happy to revert those two if you'd rather keep the narrowing there.

## Scope

Only the `namespace` variable changed. Pod/app variables and panel queries that reference the same metrics (e.g. `label_values(redis_up{...},pod)`) are untouched. All 215 JSON files still parse; 88/88 Perses and 91/91 Grafana namespace variables now conform.

Companion PR in `kubedb/installer` carries the same change for the two generated charts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opnpulse/codesmith/dashboards/pr/110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788094549&installation_model_id=19678&pr_number=110&repository=opnpulse%2Fdashboards&return_to=https%3A%2F%2Fgithub.com%2Fopnpulse%2Fdashboards%2Fpull%2F110&signature=53c64ae3d7af91648a91e1f8dfd0b06e45b3677d6c90d8e4e2e2c860f597a35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->