### PR TITLE
Regenerate Perses dashboards from the fixed pipeline

### DIFF
--- a/cassandra/cassandra_summary_dashboard-perses.json
+++ b/cassandra/cassandra_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "cassandra",
+      "db",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/cassandra/cassandra_summary_dashboard-perses.json
+++ b/cassandra/cassandra_summary_dashboard-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/clickhouse/clickhouse-database-perses.json
+++ b/clickhouse/clickhouse-database-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "clickhouse",
+      "database"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/clickhouse/clickhouse-summary-perses.json
+++ b/clickhouse/clickhouse-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "clickhouse",
+      "db",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/clickhouse/clickhouse-summary-perses.json
+++ b/clickhouse/clickhouse-summary-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/connectcluster/connectcluster-pod-perses.json
+++ b/connectcluster/connectcluster-pod-perses.json
@@ -5,6 +5,14 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "connectcluster",
+      "connector",
+      "jmx exporter",
+      "kafka",
+      "kafka-connect",
+      "kubedb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/connectcluster/connectcluster-summary-perses.json
+++ b/connectcluster/connectcluster-summary-perses.json
@@ -5,6 +5,13 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "connectcluster",
+      "db",
+      "kafka",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/connectcluster/connectcluster-summary-perses.json
+++ b/connectcluster/connectcluster-summary-perses.json
@@ -1141,6 +1141,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1149,49 +1191,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/druid/druid_database_dashboard-perses.json
+++ b/druid/druid_database_dashboard-perses.json
@@ -37,7 +37,7 @@
             "name": "Namespace",
             "hidden": false
           },
-          "defaultValue": "druid",
+          "defaultValue": "alert-druid",
           "allowAllValue": false,
           "allowMultiple": false,
           "sort": "none",
@@ -57,10 +57,10 @@
         "kind": "ListVariable",
         "spec": {
           "display": {
-            "name": "Druid",
+            "name": "App",
             "hidden": false
           },
-          "defaultValue": "druid-sample",
+          "defaultValue": "druid-grafana-demo",
           "allowAllValue": false,
           "allowMultiple": false,
           "sort": "none",
@@ -69,7 +69,7 @@
             "spec": {
               "labelName": "app",
               "matchers": [
-                "kubedb_com_druid_status_phase{namespace=~\"$namespace\"}"
+                "kubedb_com_druid_created{druid=~\".+\",namespace=~\"$namespace\"}"
               ]
             }
           },
@@ -214,7 +214,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "prometheusdata"
+                      "name": "global-ds-proxy"
                     },
                     "minStep": "",
                     "query": "druid_jvm_gc_cpu_total{service=\"$app-stats\", namespace=\"$namespace\"}",
@@ -327,7 +327,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "prometheusdata"
+                      "name": "global-ds-proxy"
                     },
                     "query": "count by(le) (druid_query_time_bucket)",
                     "seriesNameFormat": "{{le}}"
@@ -362,7 +362,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "prometheusdata"
+                      "name": "global-ds-proxy"
                     },
                     "query": "count by(le) (druid_query_wait_time_bucket)",
                     "seriesNameFormat": "{{le}}"
@@ -699,7 +699,7 @@
                   "spec": {
                     "datasource": {
                       "kind": "PrometheusDatasource",
-                      "name": "prometheusdata"
+                      "name": "global-ds-proxy"
                     },
                     "minStep": "",
                     "query": "druid_jvm_bufferpool_count{bufferpoolName=\"direct\", service=\"$app-stats\", namespace=\"$namespace\"}",

--- a/druid/druid_summary_dashboard-perses.json
+++ b/druid/druid_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "druid",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/druid/druid_summary_dashboard-perses.json
+++ b/druid/druid_summary_dashboard-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/elasticsearch/elasticsearch_database_dashboard-perses.json
+++ b/elasticsearch/elasticsearch_database_dashboard-perses.json
@@ -5,6 +5,13 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "b2c",
+      "elastic",
+      "elasticsearch",
+      "infra",
+      "kubedb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/elasticsearch/elasticsearch_pod_dashboard-perses.json
+++ b/elasticsearch/elasticsearch_pod_dashboard-perses.json
@@ -5,6 +5,13 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "b2c",
+      "elastic",
+      "elasticsearch",
+      "infra",
+      "kubedb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/elasticsearch/elasticsearch_summary_dashboard-perses.json
+++ b/elasticsearch/elasticsearch_summary_dashboard-perses.json
@@ -1396,6 +1396,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1404,49 +1446,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/hanadb/hanadb_summary_dashboard-perses.json
+++ b/hanadb/hanadb_summary_dashboard-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/hanadb/hanadb_summary_dashboard-perses.json
+++ b/hanadb/hanadb_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "hanadb",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/hazelcast/hazelcast_database_dashboard-perses.json
+++ b/hazelcast/hazelcast_database_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "database",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/hazelcast/hazelcast_pod_dashboard-perses.json
+++ b/hazelcast/hazelcast_pod_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "kubedb",
+      "pod",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/hazelcast/hazelcast_summary_dashboard-perses.json
+++ b/hazelcast/hazelcast_summary_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/hazelcast/hazelcast_summary_dashboard-perses.json
+++ b/hazelcast/hazelcast_summary_dashboard-perses.json
@@ -1588,6 +1588,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1596,49 +1638,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/ignite/ignite_database_dashboard-perses.json
+++ b/ignite/ignite_database_dashboard-perses.json
@@ -5,6 +5,9 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "ignite"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/ignite/ignite_database_dashboard-perses.json
+++ b/ignite/ignite_database_dashboard-perses.json
@@ -115,6 +115,26 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "background_solid",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Up"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/ignite/ignite_pod_dashboard-perses.json
+++ b/ignite/ignite_pod_dashboard-perses.json
@@ -5,6 +5,9 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "ignite"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/ignite/ignite_pod_dashboard-perses.json
+++ b/ignite/ignite_pod_dashboard-perses.json
@@ -115,6 +115,26 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "background_solid",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Up"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/ignite/ignite_summary_dashboard-perses.json
+++ b/ignite/ignite_summary_dashboard-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/ignite/ignite_summary_dashboard-perses.json
+++ b/ignite/ignite_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "ignite",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/kafka/kafka_summary-perses.json
+++ b/kafka/kafka_summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kafka",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/kafka/kafka_summary-perses.json
+++ b/kafka/kafka_summary-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/kubestash/kubestash_dashboard-perses.json
+++ b/kubestash/kubestash_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "backup",
+      "kubestash",
+      "restore"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/kubevault/vaultserver_summary_dashboard-perses.json
+++ b/kubevault/vaultserver_summary_dashboard-perses.json
@@ -1539,6 +1539,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1547,49 +1589,7 @@
                   }
                 ]
               },
-              "metricLabel": "terminationPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "terminationPolicy"
             }
           },
           "queries": [

--- a/kubevault/vaultserver_summary_dashboard-perses.json
+++ b/kubevault/vaultserver_summary_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "kubevault",
+      "stats",
+      "vault"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mariadb/mariadb-database-perses.json
+++ b/mariadb/mariadb-database-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "galera",
+      "mariadb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mariadb/mariadb-summary-perses.json
+++ b/mariadb/mariadb-summary-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/mariadb/mariadb-summary-perses.json
+++ b/mariadb/mariadb-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mariadb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/memcached/memcached_summary_dashboard-perses.json
+++ b/memcached/memcached_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "memcached",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/memcached/memcached_summary_dashboard-perses.json
+++ b/memcached/memcached_summary_dashboard-perses.json
@@ -950,6 +950,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -958,49 +1000,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/milvus/milvus-database-perses.json
+++ b/milvus/milvus-database-perses.json
@@ -5,6 +5,9 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "milvus2-0"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/milvus/milvus-summary-perses.json
+++ b/milvus/milvus-summary-perses.json
@@ -1067,6 +1067,27 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "background_solid",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "True"
+                    },
+                    "value": "1"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "False"
+                    },
+                    "value": "0"
+                  }
+                }
+              ],
+              "sparkline": {},
               "thresholds": {
                 "steps": [
                   {
@@ -1078,29 +1099,7 @@
                     "value": 80
                   }
                 ]
-              },
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "0",
-                    "result": {
-                      "color": "#f2495c",
-                      "value": "False"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "1",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "True"
-                    }
-                  }
-                }
-              ]
+              }
             }
           },
           "queries": [
@@ -1116,7 +1115,7 @@
                     },
                     "minStep": "",
                     "query": "kubedb_com_milvus_tls_enable{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{issuers_name}}"
                   }
                 }
               }
@@ -1296,6 +1295,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "background_solid",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1304,49 +1345,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/milvus/milvus-summary-perses.json
+++ b/milvus/milvus-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "milvus",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
@@ -5,6 +5,9 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "mongodb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-database-replset-dashboard-perses.json
@@ -19,17 +19,13 @@
             "name": "Interval",
             "hidden": false
           },
-          "defaultValue": "$__auto_interval_interval",
+          "defaultValue": "1m",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
               "values": [
-                {
-                  "label": "auto",
-                  "value": "$__auto_interval_interval"
-                },
                 "1s",
                 "5s",
                 "1m",
@@ -149,6 +145,98 @@
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "STARTUP"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "PRIMARY"
+                    },
+                    "value": "1"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "REMOVED"
+                    },
+                    "value": "10"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "SECONDARY"
+                    },
+                    "value": "2"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "RECOVERING"
+                    },
+                    "value": "3"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "STARTUP2"
+                    },
+                    "value": "5"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "UNKNOWN"
+                    },
+                    "value": "6"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "ARBITER"
+                    },
+                    "value": "7"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "DOWN"
+                    },
+                    "value": "8"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "ROLLBACK"
+                    },
+                    "value": "9"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -378,13 +466,13 @@
           "plugin": {
             "kind": "StatChart",
             "spec": {
-              "calculation": "mean",
+              "calculation": "last-number",
               "colorMode": "none",
               "format": {
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
-              "metricLabel": " engine ",
+              "metricLabel": "engine",
               "thresholds": {
                 "steps": [
                   {
@@ -412,7 +500,7 @@
                     },
                     "minStep": "5m",
                     "query": "mongodb_mongod_storage_engine{pod=~\"$pod\"}",
-                    "seriesNameFormat": "{{ engine }}"
+                    "seriesNameFormat": "{{engine}}"
                   }
                 }
               }

--- a/mongodb/legacy/mongodb-pod-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-pod-dashboard-perses.json
@@ -26,10 +26,6 @@
             "kind": "StaticListVariable",
             "spec": {
               "values": [
-                {
-                  "label": "auto",
-                  "value": "$__auto_interval_interval"
-                },
                 "1s",
                 "5s",
                 "1m",

--- a/mongodb/legacy/mongodb-pod-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-pod-dashboard-perses.json
@@ -5,6 +5,9 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "mongodb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mongodb/legacy/mongodb-summary-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-summary-dashboard-perses.json
@@ -260,11 +260,25 @@
                   "name": "value #5"
                 },
                 {
-                  "format": {
-                    "unit": "decimal"
-                  },
                   "header": "Pod",
-                  "name": "pod"
+                  "name": "pod #1",
+                  "align": "left"
+                },
+                {
+                  "name": "pod #2",
+                  "hide": true
+                },
+                {
+                  "name": "pod #3",
+                  "hide": true
+                },
+                {
+                  "name": "pod #4",
+                  "hide": true
+                },
+                {
+                  "name": "pod #5",
+                  "hide": true
                 }
               ]
             }
@@ -467,11 +481,37 @@
                   "name": "value #8"
                 },
                 {
-                  "format": {
-                    "unit": "decimal"
-                  },
                   "header": "Pod",
-                  "name": "pod"
+                  "name": "pod #1",
+                  "align": "left"
+                },
+                {
+                  "name": "pod #2",
+                  "hide": true
+                },
+                {
+                  "name": "pod #3",
+                  "hide": true
+                },
+                {
+                  "name": "pod #4",
+                  "hide": true
+                },
+                {
+                  "name": "pod #5",
+                  "hide": true
+                },
+                {
+                  "name": "pod #6",
+                  "hide": true
+                },
+                {
+                  "name": "pod #7",
+                  "hide": true
+                },
+                {
+                  "name": "pod #8",
+                  "hide": true
                 }
               ]
             }
@@ -886,11 +926,29 @@
                   "name": "value #6"
                 },
                 {
-                  "format": {
-                    "unit": "decimal"
-                  },
                   "header": "Pod",
-                  "name": "pod"
+                  "name": "pod #1",
+                  "align": "left"
+                },
+                {
+                  "name": "pod #2",
+                  "hide": true
+                },
+                {
+                  "name": "pod #3",
+                  "hide": true
+                },
+                {
+                  "name": "pod #4",
+                  "hide": true
+                },
+                {
+                  "name": "pod #5",
+                  "hide": true
+                },
+                {
+                  "name": "pod #6",
+                  "hide": true
                 }
               ]
             }
@@ -1247,13 +1305,12 @@
           "plugin": {
             "kind": "StatChart",
             "spec": {
-              "calculation": "mean",
+              "calculation": "last-number",
               "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
               "metricLabel": "version",
-              "sparkline": {},
               "thresholds": {
                 "steps": [
                   {
@@ -1439,7 +1496,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
-              "sparkline": {},
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1447,7 +1545,8 @@
                     "value": 0
                   }
                 ]
-              }
+              },
+              "metricLabel": "terminationPolicy"
             }
           },
           "queries": [

--- a/mongodb/legacy/mongodb-summary-dashboard-perses.json
+++ b/mongodb/legacy/mongodb-summary-dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mongodb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mongodb/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/mongodb-database-replset-dashboard-perses.json
@@ -149,82 +149,91 @@
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "1",
+                    "result": {
+                      "value": "STARTUP"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
                     "result": {
                       "value": "PRIMARY"
-                    }
+                    },
+                    "value": "1"
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "2",
-                    "result": {
-                      "value": "SECONDARY"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "3",
-                    "result": {
-                      "value": "RECOVERING"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "5",
-                    "result": {
-                      "value": "STARTUP2"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "6",
-                    "result": {
-                      "value": "UNKNOWN"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "7",
-                    "result": {
-                      "value": "ARBITER"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "8",
-                    "result": {
-                      "value": "DOWN"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "9",
-                    "result": {
-                      "value": "ROLLBACK"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "10",
                     "result": {
                       "value": "REMOVED"
-                    }
+                    },
+                    "value": "10"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "SECONDARY"
+                    },
+                    "value": "2"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "RECOVERING"
+                    },
+                    "value": "3"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "STARTUP2"
+                    },
+                    "value": "5"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "UNKNOWN"
+                    },
+                    "value": "6"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "ARBITER"
+                    },
+                    "value": "7"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "DOWN"
+                    },
+                    "value": "8"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "ROLLBACK"
+                    },
+                    "value": "9"
                   }
                 }
               ],

--- a/mongodb/mongodb-database-replset-dashboard-perses.json
+++ b/mongodb/mongodb-database-replset-dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mongodb",
+      "replicaset"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mongodb/mongodb-pod-dashboard-perses.json
+++ b/mongodb/mongodb-pod-dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mongodb",
+      "pod"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mongodb/mongodb-summary-dashboard-perses.json
+++ b/mongodb/mongodb-summary-dashboard-perses.json
@@ -1582,6 +1582,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1590,49 +1632,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/mongodb/mongodb-summary-dashboard-perses.json
+++ b/mongodb/mongodb-summary-dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mongodb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mssqlserver/mssqlserver_database_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_database_dashboard-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "galera",
+      "mysql"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mssqlserver/mssqlserver_pod_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_pod_dashboard-perses.json
@@ -204,6 +204,27 @@
                 "decimalPlaces": 1,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Running"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -343,38 +364,38 @@
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
-              "metricLabel": "role",
               "mappings": [
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "master",
                     "result": {
                       "color": "#5794f2",
                       "value": "master"
-                    }
+                    },
+                    "value": "master"
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "slave",
                     "result": {
                       "color": "#8ab8ff",
                       "value": "slave"
-                    }
+                    },
+                    "value": "slave"
                   }
                 },
                 {
                   "kind": "Misc",
                   "spec": {
-                    "value": "null",
                     "result": {
                       "value": "N/A"
-                    }
+                    },
+                    "value": "null"
                   }
                 }
               ],
+              "metricLabel": "role",
               "thresholds": {
                 "steps": [
                   {

--- a/mssqlserver/mssqlserver_summary_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_summary_dashboard-perses.json
@@ -1265,6 +1265,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1273,49 +1315,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/mssqlserver/mssqlserver_summary_dashboard-perses.json
+++ b/mssqlserver/mssqlserver_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mssqlserver",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mysql/mysql_database_dashboard-perses.json
+++ b/mysql/mysql_database_dashboard-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "galera",
+      "mysql"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/mysql/mysql_summary_dashboard-perses.json
+++ b/mysql/mysql_summary_dashboard-perses.json
@@ -1364,6 +1364,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1372,49 +1414,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/mysql/mysql_summary_dashboard-perses.json
+++ b/mysql/mysql_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "mysql",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/neo4j/neo4j-database-perses.json
+++ b/neo4j/neo4j-database-perses.json
@@ -179,21 +179,19 @@
             "name": "Nodes"
           },
           "plugin": {
-            "kind": "GaugeChart",
+            "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "sparkline": {},
               "thresholds": {
                 "steps": [
                   {
                     "color": "#73bf69",
                     "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
                   }
                 ]
               }
@@ -228,7 +226,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -295,6 +314,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -365,7 +399,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -396,7 +451,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -427,8 +503,30 @@
             "description": "The ratio of hits to the total number of lookups in the page cache"
           },
           "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent-decimal"
+              },
+              "max": 1,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 0.95
+                  }
+                ]
+              }
+            }
           },
           "queries": [
             {
@@ -460,7 +558,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -492,7 +611,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -524,7 +664,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -555,7 +716,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -587,7 +769,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -668,21 +871,19 @@
             "name": "Relationships"
           },
           "plugin": {
-            "kind": "GaugeChart",
+            "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "sparkline": {},
               "thresholds": {
                 "steps": [
                   {
                     "color": "#73bf69",
                     "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
                   }
                 ]
               }
@@ -717,7 +918,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -750,9 +972,24 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
-                  "unit": "decbytes"
+                  "unit": "bytes"
                 }
               }
             }
@@ -786,7 +1023,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -817,7 +1075,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -866,7 +1145,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -923,7 +1223,7 @@
           ]
         }
       },
-      "26": {
+      "25": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -931,7 +1231,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -963,6 +1284,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "bytes"
@@ -1000,7 +1336,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "percent"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1202,6 +1559,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -1239,7 +1611,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1283,14 +1676,14 @@
             {
               "x": 8,
               "y": 1,
-              "width": 6,
+              "width": 8,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/1"
               }
             },
             {
-              "x": 15,
+              "x": 16,
               "y": 1,
               "width": 8,
               "height": 4,
@@ -1302,7 +1695,7 @@
               "x": 0,
               "y": 6,
               "width": 12,
-              "height": 11,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/3"
               }
@@ -1311,140 +1704,140 @@
               "x": 12,
               "y": 6,
               "width": 12,
-              "height": 11,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4"
               }
             },
             {
               "x": 0,
-              "y": 18,
-              "width": 4,
-              "height": 4,
+              "y": 15,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/5"
               }
             },
             {
-              "x": 4,
-              "y": 18,
-              "width": 10,
-              "height": 5,
+              "x": 12,
+              "y": 15,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/6"
               }
             },
             {
-              "x": 15,
-              "y": 18,
-              "width": 9,
-              "height": 13,
+              "x": 0,
+              "y": 23,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/7"
               }
             },
             {
-              "x": 0,
+              "x": 12,
               "y": 23,
-              "width": 7,
+              "width": 12,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/8"
               }
             },
             {
-              "x": 7,
-              "y": 23,
-              "width": 8,
+              "x": 0,
+              "y": 31,
+              "width": 12,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/9"
               }
             },
             {
-              "x": 0,
+              "x": 12,
               "y": 31,
-              "width": 9,
-              "height": 6,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/10"
               }
             },
             {
-              "x": 9,
-              "y": 31,
-              "width": 15,
-              "height": 5,
+              "x": 0,
+              "y": 39,
+              "width": 24,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/11"
               }
             },
             {
               "x": 0,
-              "y": 38,
-              "width": 7,
-              "height": 7,
+              "y": 48,
+              "width": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/12"
               }
             },
             {
-              "x": 7,
-              "y": 38,
-              "width": 8,
-              "height": 6,
+              "x": 6,
+              "y": 48,
+              "width": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/13"
               }
             },
             {
-              "x": 15,
-              "y": 38,
-              "width": 9,
-              "height": 7,
+              "x": 12,
+              "y": 48,
+              "width": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/14"
               }
             },
             {
-              "x": 0,
-              "y": 45,
+              "x": 18,
+              "y": 48,
               "width": 6,
-              "height": 7,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/15"
               }
             },
             {
-              "x": 6,
-              "y": 45,
-              "width": 6,
-              "height": 6,
+              "x": 0,
+              "y": 56,
+              "width": 8,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/16"
               }
             },
             {
-              "x": 12,
-              "y": 45,
-              "width": 6,
-              "height": 6,
+              "x": 8,
+              "y": 56,
+              "width": 8,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/17"
               }
             },
             {
-              "x": 18,
-              "y": 45,
-              "width": 6,
-              "height": 6,
+              "x": 16,
+              "y": 56,
+              "width": 8,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/18"
               }
             },
             {
               "x": 0,
-              "y": 53,
+              "y": 65,
               "width": 12,
               "height": 9,
               "content": {
@@ -1453,8 +1846,8 @@
             },
             {
               "x": 12,
-              "y": 53,
-              "width": 11,
+              "y": 65,
+              "width": 12,
               "height": 9,
               "content": {
                 "$ref": "#/spec/panels/20"
@@ -1462,47 +1855,47 @@
             },
             {
               "x": 0,
-              "y": 63,
-              "width": 13,
-              "height": 9,
+              "y": 75,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/21"
               }
             },
             {
-              "x": 14,
-              "y": 63,
-              "width": 8,
-              "height": 9,
+              "x": 12,
+              "y": 75,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/22"
               }
             },
             {
               "x": 0,
-              "y": 72,
+              "y": 83,
               "width": 12,
-              "height": 9,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/23"
               }
             },
             {
               "x": 12,
-              "y": 72,
+              "y": 83,
               "width": 12,
-              "height": 9,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/24"
               }
             },
             {
               "x": 0,
-              "y": 82,
+              "y": 92,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/26"
+                "$ref": "#/spec/panels/25"
               }
             }
           ]

--- a/neo4j/neo4j-pod-perses.json
+++ b/neo4j/neo4j-pod-perses.json
@@ -157,28 +157,27 @@
               "calculation": "last-number",
               "colorMode": "background_solid",
               "format": {
-                "decimalPlaces": 0,
+                "decimalPlaces": 1,
                 "unit": "decimal"
               },
               "mappings": [
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "0",
                     "result": {
-                      "color": "#f2cc0c",
+                      "color": "#fade2a",
                       "value": "Down"
-                    }
+                    },
+                    "value": "0"
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "1",
                     "result": {
-                      "color": "rgba(50, 172, 45, 0.97)",
                       "value": "Running"
-                    }
+                    },
+                    "value": "1"
                   }
                 }
               ],
@@ -272,6 +271,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -309,7 +323,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -342,6 +377,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -378,7 +428,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -392,7 +463,7 @@
                       "name": "global-ds-proxy"
                     },
                     "minStep": "",
-                    "query": "neo4j_database_${database}_transaction_committed_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "query": "neo4j_database_${database}_transaction_committed_total{pod =~\"$pod\",namespace=~\"$namespace\"}",
                     "seriesNameFormat": "Total Committed Tr.s {{instance}}"
                   }
                 }
@@ -445,6 +516,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -515,7 +601,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -546,7 +653,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -577,8 +705,30 @@
             "description": "The ratio of hits to the total number of lookups in the page cache"
           },
           "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent-decimal"
+              },
+              "max": 1,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 0.95
+                  }
+                ]
+              }
+            }
           },
           "queries": [
             {
@@ -610,7 +760,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -642,7 +813,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -721,7 +913,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -752,7 +965,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -784,7 +1018,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -866,7 +1121,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -899,9 +1175,24 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
-                  "unit": "decbytes"
+                  "unit": "bytes"
                 }
               }
             }
@@ -935,7 +1226,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -966,7 +1278,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1015,7 +1348,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1072,7 +1426,7 @@
           ]
         }
       },
-      "29": {
+      "28": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1080,7 +1434,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1112,6 +1487,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "bytes"
@@ -1149,7 +1539,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "percent"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1227,11 +1638,43 @@
             "description": "Instant rate"
           },
           "plugin": {
-            "kind": "Markdown",
+            "kind": "StatChart",
             "spec": {
-              "text": "**Migration from Grafana not supported !**"
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "ops/sec"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
             }
-          }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "global-ds-proxy"
+                    },
+                    "minStep": "",
+                    "query": "irate(neo4j_database_${database}_transaction_committed_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       "7": {
@@ -1242,11 +1685,43 @@
             "description": "This is in reality the change in neo4j ids.\nIf the transaction is rolled-back nodes will not be created but will increase this gauge.\n\nMaximum speed is set to 30k nodes/sec\nEmpirically we saw this is the maximum handled by the production machine"
           },
           "plugin": {
-            "kind": "Markdown",
+            "kind": "StatChart",
             "spec": {
-              "text": "**Migration from Grafana not supported !**"
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
             }
-          }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "global-ds-proxy"
+                    },
+                    "minStep": "",
+                    "query": "irate(neo4j_database_${database}_ids_in_use_property{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       "8": {
@@ -1257,11 +1732,43 @@
             "description": "Instant rate"
           },
           "plugin": {
-            "kind": "Markdown",
+            "kind": "StatChart",
             "spec": {
-              "text": "**Migration from Grafana not supported !**"
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "ops/sec"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
             }
-          }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "global-ds-proxy"
+                    },
+                    "minStep": "",
+                    "query": "irate(neo4j_database_${database}_transaction_rollbacks_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       "9": {
@@ -1273,7 +1780,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1353,7 +1881,7 @@
               "x": 0,
               "y": 6,
               "width": 12,
-              "height": 11,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/3"
               }
@@ -1362,78 +1890,78 @@
               "x": 12,
               "y": 6,
               "width": 12,
-              "height": 11,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4"
               }
             },
             {
               "x": 0,
-              "y": 18,
-              "width": 4,
+              "y": 15,
+              "width": 6,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/5"
               }
             },
             {
-              "x": 4,
-              "y": 18,
-              "width": 4,
+              "x": 6,
+              "y": 15,
+              "width": 6,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/6"
               }
             },
             {
-              "x": 8,
-              "y": 18,
-              "width": 3,
+              "x": 12,
+              "y": 15,
+              "width": 6,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/7"
               }
             },
             {
-              "x": 11,
-              "y": 18,
-              "width": 3,
+              "x": 18,
+              "y": 15,
+              "width": 6,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/8"
               }
             },
             {
-              "x": 14,
-              "y": 18,
-              "width": 10,
-              "height": 5,
+              "x": 0,
+              "y": 19,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/9"
               }
             },
             {
-              "x": 0,
-              "y": 22,
-              "width": 7,
+              "x": 12,
+              "y": 19,
+              "width": 12,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/10"
               }
             },
             {
-              "x": 7,
-              "y": 23,
-              "width": 8,
+              "x": 0,
+              "y": 27,
+              "width": 12,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/11"
               }
             },
             {
-              "x": 15,
-              "y": 23,
-              "width": 8,
+              "x": 12,
+              "y": 27,
+              "width": 12,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/12"
@@ -1441,89 +1969,89 @@
             },
             {
               "x": 0,
-              "y": 31,
-              "width": 9,
-              "height": 6,
+              "y": 35,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/13"
               }
             },
             {
-              "x": 9,
-              "y": 31,
-              "width": 15,
-              "height": 5,
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/14"
               }
             },
             {
               "x": 0,
-              "y": 38,
-              "width": 7,
-              "height": 7,
+              "y": 44,
+              "width": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/15"
               }
             },
             {
-              "x": 7,
-              "y": 38,
-              "width": 8,
-              "height": 6,
+              "x": 6,
+              "y": 44,
+              "width": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/16"
               }
             },
             {
-              "x": 15,
-              "y": 38,
-              "width": 9,
-              "height": 7,
+              "x": 12,
+              "y": 44,
+              "width": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/17"
               }
             },
             {
-              "x": 0,
-              "y": 45,
+              "x": 18,
+              "y": 44,
               "width": 6,
-              "height": 7,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/18"
               }
             },
             {
-              "x": 6,
-              "y": 45,
-              "width": 6,
-              "height": 6,
+              "x": 0,
+              "y": 52,
+              "width": 8,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/19"
               }
             },
             {
-              "x": 12,
-              "y": 45,
-              "width": 6,
-              "height": 6,
+              "x": 8,
+              "y": 52,
+              "width": 8,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/20"
               }
             },
             {
-              "x": 18,
-              "y": 45,
-              "width": 6,
-              "height": 6,
+              "x": 16,
+              "y": 52,
+              "width": 8,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/21"
               }
             },
             {
-              "x": 1,
-              "y": 53,
-              "width": 10,
+              "x": 0,
+              "y": 61,
+              "width": 12,
               "height": 9,
               "content": {
                 "$ref": "#/spec/panels/22"
@@ -1531,8 +2059,8 @@
             },
             {
               "x": 12,
-              "y": 53,
-              "width": 11,
+              "y": 61,
+              "width": 12,
               "height": 9,
               "content": {
                 "$ref": "#/spec/panels/23"
@@ -1540,47 +2068,47 @@
             },
             {
               "x": 0,
-              "y": 63,
-              "width": 13,
-              "height": 9,
+              "y": 71,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/24"
               }
             },
             {
-              "x": 14,
-              "y": 63,
-              "width": 8,
-              "height": 9,
+              "x": 12,
+              "y": 71,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/25"
               }
             },
             {
               "x": 0,
-              "y": 72,
-              "width": 11,
-              "height": 9,
+              "y": 79,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/26"
               }
             },
             {
-              "x": 13,
-              "y": 72,
-              "width": 8,
-              "height": 9,
+              "x": 12,
+              "y": 79,
+              "width": 12,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/27"
               }
             },
             {
               "x": 0,
-              "y": 82,
+              "y": 88,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/29"
+                "$ref": "#/spec/panels/28"
               }
             }
           ]

--- a/neo4j/neo4j-summary-perses.json
+++ b/neo4j/neo4j-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "neo4j",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/neo4j/neo4j-summary-perses.json
+++ b/neo4j/neo4j-summary-perses.json
@@ -186,12 +186,72 @@
         "kind": "Panel",
         "spec": {
           "display": {
+            "name": "TLS Channels",
+            "description": "TLS mode per Neo4j channel. On when the channel uses TLS/mTLS with a configured issuer; Off otherwise."
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "name": "Channel",
+                  "width": 160
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "global-ds-proxy"
+                    },
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"kubedb_com_neo4j_tls_(bolt|http|cluster|backup)_mode\", namespace=\"$namespace\", app=\"$app\"}, \"channel\", \"$1\", \"__name__\", \"kubedb_com_neo4j_tls_(.+)_mode\")",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
             "name": "CPU Usage",
             "description": "CPU Usage by NEO4J pods"
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -214,7 +274,7 @@
           ]
         }
       },
-      "11": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -378,7 +438,7 @@
           ]
         }
       },
-      "12": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -388,6 +448,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "bytes"
@@ -416,7 +491,7 @@
           ]
         }
       },
-      "13": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -662,7 +737,7 @@
           ]
         }
       },
-      "14": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -672,6 +747,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "bytes"
@@ -700,7 +790,7 @@
           ]
         }
       },
-      "15": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -710,6 +800,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -755,7 +860,7 @@
           ]
         }
       },
-      "16": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -764,6 +869,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "decimal"
@@ -792,7 +912,7 @@
           ]
         }
       },
-      "17": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -801,6 +921,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "bytes/sec"
@@ -829,7 +964,7 @@
           ]
         }
       },
-      "18": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1019,7 +1154,75 @@
           ]
         }
       },
-      "19": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "True"
+                    },
+                    "value": "1"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "False"
+                    },
+                    "value": "0"
+                  }
+                }
+              ],
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "global-ds-proxy"
+                    },
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_tls_enabled{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{issuers_name}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1053,76 +1256,7 @@
           ]
         }
       },
-      "2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Require Secure Transport",
-            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "colorMode": "background_solid",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "0",
-                    "result": {
-                      "color": "#f2495c",
-                      "value": "False"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "1",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "True"
-                    }
-                  }
-                }
-              ],
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "global-ds-proxy"
-                    },
-                    "minStep": "",
-                    "query": "kubedb_com_neo4j_tls_enabled{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "20": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1159,7 +1293,7 @@
           ]
         }
       },
-      "21": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1214,7 +1348,7 @@
           ]
         }
       },
-      "22": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1222,7 +1356,28 @@
           },
           "plugin": {
             "kind": "TimeSeriesChart",
-            "spec": {}
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
           },
           "queries": [
             {
@@ -1245,7 +1400,7 @@
           ]
         }
       },
-      "23": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1254,6 +1409,21 @@
           "plugin": {
             "kind": "TimeSeriesChart",
             "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "mean"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
               "yAxis": {
                 "format": {
                   "unit": "bytes/sec"
@@ -1298,45 +1468,44 @@
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "WipeOut",
                     "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
+                      "color": "#fade2a",
                       "value": "Delete"
-                    }
+                    },
+                    "value": "Delete"
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
                     "result": {
                       "color": "#73bf69",
                       "value": "DoNotTerminate"
-                    }
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
                   }
                 }
               ],
-              "metricLabel": "deletionPolicy",
               "thresholds": {
                 "steps": [
                   {
@@ -1344,7 +1513,8 @@
                     "value": 0
                   }
                 ]
-              }
+              },
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [
@@ -1643,108 +1813,6 @@
             }
           ]
         }
-      },
-      "24": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "TLS Channels",
-            "description": "TLS mode per Neo4j channel (State 1 = TLS/mTLS on, 0 = off)."
-          },
-          "plugin": {
-            "kind": "Table",
-            "spec": {
-              "columnSettings": [
-                {
-                  "name": "timestamp",
-                  "hide": true
-                },
-                {
-                  "name": "__name__",
-                  "hide": true
-                },
-                {
-                  "name": "app",
-                  "hide": true
-                },
-                {
-                  "name": "app_namespace",
-                  "hide": true
-                },
-                {
-                  "name": "namespace",
-                  "hide": true
-                },
-                {
-                  "name": "container",
-                  "hide": true
-                },
-                {
-                  "name": "endpoint",
-                  "hide": true
-                },
-                {
-                  "name": "instance",
-                  "hide": true
-                },
-                {
-                  "name": "job",
-                  "hide": true
-                },
-                {
-                  "name": "neo4j",
-                  "hide": true
-                },
-                {
-                  "name": "pod",
-                  "hide": true
-                },
-                {
-                  "name": "service",
-                  "hide": true
-                },
-                {
-                  "name": "prometheus",
-                  "hide": true
-                },
-                {
-                  "name": "channel",
-                  "header": "Channel",
-                  "align": "left"
-                },
-                {
-                  "name": "mode",
-                  "header": "Mode",
-                  "align": "center"
-                },
-                {
-                  "name": "value",
-                  "header": "State (1=On)",
-                  "align": "center"
-                }
-              ]
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "global-ds-proxy"
-                    },
-                    "minStep": "",
-                    "query": "label_replace({__name__=~\"kubedb_com_neo4j_tls_(bolt|http|cluster|backup)_mode\", namespace=\"$namespace\", app=\"$app\"}, \"channel\", \"$1\", \"__name__\", \"kubedb_com_neo4j_tls_(.+)_mode\")",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
       }
     },
     "layouts": [
@@ -1847,11 +1915,11 @@
             },
             {
               "x": 0,
-              "y": 8,
+              "y": 7,
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/24"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -1860,7 +1928,7 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/10"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -1869,7 +1937,7 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/11"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1878,7 +1946,7 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/12"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -1887,20 +1955,11 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/13"
-              }
-            },
-            {
-              "x": 0,
-              "y": 41,
-              "width": 12,
-              "height": 9,
-              "content": {
                 "$ref": "#/spec/panels/14"
               }
             },
             {
-              "x": 12,
+              "x": 0,
               "y": 41,
               "width": 12,
               "height": 9,
@@ -1909,16 +1968,16 @@
               }
             },
             {
-              "x": 0,
-              "y": 50,
+              "x": 12,
+              "y": 41,
               "width": 12,
-              "height": 7,
+              "height": 9,
               "content": {
                 "$ref": "#/spec/panels/16"
               }
             },
             {
-              "x": 12,
+              "x": 0,
               "y": 50,
               "width": 12,
               "height": 7,
@@ -1927,9 +1986,9 @@
               }
             },
             {
-              "x": 0,
-              "y": 57,
-              "width": 24,
+              "x": 12,
+              "y": 50,
+              "width": 12,
               "height": 7,
               "content": {
                 "$ref": "#/spec/panels/18"
@@ -1937,15 +1996,15 @@
             },
             {
               "x": 0,
-              "y": 65,
-              "width": 12,
-              "height": 6,
+              "y": 57,
+              "width": 24,
+              "height": 7,
               "content": {
                 "$ref": "#/spec/panels/19"
               }
             },
             {
-              "x": 12,
+              "x": 0,
               "y": 65,
               "width": 12,
               "height": 6,
@@ -1954,12 +2013,21 @@
               }
             },
             {
+              "x": 12,
+              "y": 65,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
               "x": 0,
               "y": 71,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/21"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -1968,7 +2036,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/22"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1977,7 +2045,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/23"
+                "$ref": "#/spec/panels/24"
               }
             }
           ]

--- a/oracle/oracle_database_dashboard-perses.json
+++ b/oracle/oracle_database_dashboard-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "galera",
+      "oracle"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/oracle/oracle_pod_dashboard-perses.json
+++ b/oracle/oracle_pod_dashboard-perses.json
@@ -204,6 +204,27 @@
                 "decimalPlaces": 1,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Running"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -250,38 +271,38 @@
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
-              "metricLabel": "role",
               "mappings": [
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "master",
                     "result": {
                       "color": "#5794f2",
                       "value": "master"
-                    }
+                    },
+                    "value": "master"
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "slave",
                     "result": {
                       "color": "#8ab8ff",
                       "value": "slave"
-                    }
+                    },
+                    "value": "slave"
                   }
                 },
                 {
                   "kind": "Misc",
                   "spec": {
-                    "value": "null",
                     "result": {
                       "value": "N/A"
-                    }
+                    },
+                    "value": "null"
                   }
                 }
               ],
+              "metricLabel": "role",
               "thresholds": {
                 "steps": [
                   {

--- a/oracle/oracle_summary_dashboard-perses.json
+++ b/oracle/oracle_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "oracle",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/oracle/oracle_summary_dashboard-perses.json
+++ b/oracle/oracle_summary_dashboard-perses.json
@@ -1582,6 +1582,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1590,49 +1632,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/perconaxtradb/perconaxtradb-database-perses.json
+++ b/perconaxtradb/perconaxtradb-database-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "galera",
+      "perconaxtradb"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/perconaxtradb/perconaxtradb-summary-perses.json
+++ b/perconaxtradb/perconaxtradb-summary-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/perconaxtradb/perconaxtradb-summary-perses.json
+++ b/perconaxtradb/perconaxtradb-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "perconaxtradb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgbouncer/pgbouncer_database-perses.json
+++ b/pgbouncer/pgbouncer_database-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "pgbouncer",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgbouncer/pgbouncer_pod-perses.json
+++ b/pgbouncer/pgbouncer_pod-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "pgbouncer",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgbouncer/pgbouncer_summary-perses.json
+++ b/pgbouncer/pgbouncer_summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "pgbouncer",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgbouncer/pgbouncer_summary-perses.json
+++ b/pgbouncer/pgbouncer_summary-perses.json
@@ -1227,6 +1227,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1235,49 +1277,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/pgpool/pgpool_database-perses.json
+++ b/pgpool/pgpool_database-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "pgpool",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgpool/pgpool_pod-perses.json
+++ b/pgpool/pgpool_pod-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "pgpool",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgpool/pgpool_summary-perses.json
+++ b/pgpool/pgpool_summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "pgpool",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/pgpool/pgpool_summary-perses.json
+++ b/pgpool/pgpool_summary-perses.json
@@ -1227,6 +1227,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1235,49 +1277,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/postgres/postgres_databases_dashboard-perses.json
+++ b/postgres/postgres_databases_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "postgres",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/postgres/postgres_pods_dashboard-perses.json
+++ b/postgres/postgres_pods_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "postgres",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/postgres/postgres_pods_dashboard-perses.json
+++ b/postgres/postgres_pods_dashboard-perses.json
@@ -164,21 +164,21 @@
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "0",
                     "result": {
                       "color": "#ffffff",
                       "value": "Primary"
-                    }
+                    },
+                    "value": "0"
                   }
                 },
                 {
                   "kind": "Value",
                   "spec": {
-                    "value": "1",
                     "result": {
                       "color": "#ffffff",
                       "value": "Standby"
-                    }
+                    },
+                    "value": "1"
                   }
                 }
               ],

--- a/postgres/postgres_remote_replica_dashboard-perses.json
+++ b/postgres/postgres_remote_replica_dashboard-perses.json
@@ -1,7 +1,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "kubedb-redissentinel-pod",
+    "name": "kubedb-postgres-remotereplica",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
@@ -9,7 +9,7 @@
   },
   "spec": {
     "display": {
-      "name": "KubeDB / RedisSentinel / Pod"
+      "name": "KubeDB / Postgres / Remote Replica"
     },
     "variables": [
       {
@@ -18,7 +18,6 @@
           "display": {
             "hidden": false
           },
-          "defaultValue": "Prometheus",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
@@ -34,13 +33,11 @@
         "kind": "ListVariable",
         "spec": {
           "display": {
-            "name": "Namespace",
             "hidden": false
           },
-          "defaultValue": "demo",
           "allowAllValue": false,
           "allowMultiple": false,
-          "sort": "none",
+          "sort": "alphabetical-asc",
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
@@ -57,44 +54,21 @@
         "kind": "ListVariable",
         "spec": {
           "display": {
-            "name": "redissentinel",
             "hidden": false
           },
-          "defaultValue": "sentinel",
-          "allowAllValue": false,
-          "allowMultiple": false,
-          "sort": "alphabetical-asc",
-          "plugin": {
-            "kind": "PrometheusPromQLVariable",
-            "spec": {
-              "expr": "query_result(kubedb_com_redissentinel_created{namespace=\"$namespace\"})",
-              "labelName": "migration_from_grafana_not_supported"
-            }
-          },
-          "name": "app"
-        }
-      },
-      {
-        "kind": "ListVariable",
-        "spec": {
-          "display": {
-            "name": "Pod Name",
-            "hidden": false
-          },
-          "defaultValue": "sentinel-0",
           "allowAllValue": false,
           "allowMultiple": false,
           "sort": "alphabetical-asc",
           "plugin": {
             "kind": "PrometheusLabelValuesVariable",
             "spec": {
-              "labelName": "pod",
+              "labelName": "app",
               "matchers": [
-                "redis_up{namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+                "kubedb_com_postgres_info{namespace=\"$namespace\"}"
               ]
             }
           },
-          "name": "pod"
+          "name": "app"
         }
       }
     ],
@@ -103,43 +77,26 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Status"
+            "name": "Streaming",
+            "description": "1: every pod is confirmed streaming by the source (in pg_stat_replication). 0: at least one pod is not \u2014 the standby role label is cleared for it."
           },
           "plugin": {
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "colorMode": "none",
+              "colorMode": "background_solid",
               "format": {
-                "decimalPlaces": 1,
                 "unit": "decimal"
               },
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#fade2a",
-                      "value": "Down"
-                    },
-                    "value": "0"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Running"
-                    },
-                    "value": "1"
-                  }
-                }
-              ],
               "thresholds": {
                 "steps": [
                   {
-                    "color": "rgba(50, 172, 45, 0.97)",
+                    "color": "#f2495c",
                     "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
                   }
                 ]
               }
@@ -156,9 +113,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "redis_up{pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "query": "min(pg_coordinator_remote_replica_streaming{namespace=\"$namespace\", pod=~\"${app}-.*\"})"
                   }
                 }
               }
@@ -170,26 +125,26 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Connected Clients"
+            "name": "Source Reachable",
+            "description": "1: the coordinator can query the source primary. 0: it cannot \u2014 a DR replica that cannot see its source is not protecting anything."
           },
           "plugin": {
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "colorMode": "none",
+              "colorMode": "background_solid",
               "format": {
-                "decimalPlaces": 0,
                 "unit": "decimal"
               },
               "thresholds": {
                 "steps": [
                   {
-                    "color": "#73bf69",
+                    "color": "#f2495c",
                     "value": 0
                   },
                   {
-                    "color": "#f2495c",
-                    "value": 80
+                    "color": "#73bf69",
+                    "value": 1
                   }
                 ]
               }
@@ -206,9 +161,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "redis_connected_clients{pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "query": "min(pg_coordinator_remote_replica_source_reachable{namespace=\"$namespace\", pod=~\"${app}-.*\"})"
                   }
                 }
               }
@@ -220,11 +173,34 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Commands Executed / sec"
+            "name": "Replication Lag (RPO)",
+            "description": "Bytes of WAL the source has written beyond what this replica has replayed \u2014 the data at risk if the source DC is lost right now."
           },
           "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decbytes"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 16777216
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 134217728
+                  }
+                ]
+              }
+            }
           },
           "queries": [
             {
@@ -237,9 +213,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "rate(redis_commands_processed_total{pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
+                    "query": "max(pg_coordinator_remote_replica_lag_bytes{namespace=\"$namespace\", pod=~\"${app}-.*\"})"
                   }
                 }
               }
@@ -251,13 +225,14 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Uptime"
+            "name": "Lag Data Age",
+            "description": "Seconds since the last successful lag measurement. The monitor backs off to 300s while in sync; sustained values above ~330s mean measurements are failing."
           },
           "plugin": {
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "colorMode": "none",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "seconds"
               },
@@ -268,8 +243,12 @@
                     "value": 0
                   },
                   {
+                    "color": "#fade2a",
+                    "value": 330
+                  },
+                  {
                     "color": "#f2495c",
-                    "value": 80
+                    "value": 900
                   }
                 ]
               }
@@ -286,9 +265,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "max(max_over_time(redis_uptime_in_seconds{pod=~\"$pod\"}[$__interval]))",
-                    "seriesNameFormat": ""
+                    "query": "time() - min(pg_coordinator_remote_replica_last_lag_check_timestamp_seconds{namespace=\"$namespace\", pod=~\"${app}-.*\"})"
                   }
                 }
               }
@@ -300,16 +277,15 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Go Routines",
-            "description": "Number of goroutines that currently exist"
+            "name": "Recoveries (24h)",
+            "description": "pg_rewind / pg_basebackup actions in the last 24h. Every recovery deserves an incident review: something made the replica diverge or fall off."
           },
           "plugin": {
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "colorMode": "none",
+              "colorMode": "background_solid",
               "format": {
-                "decimalPlaces": 0,
                 "unit": "decimal"
               },
               "thresholds": {
@@ -317,10 +293,17 @@
                   {
                     "color": "#73bf69",
                     "value": 0
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 1
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 3
                   }
                 ]
-              },
-              "valueFontSize": 32
+              }
             }
           },
           "queries": [
@@ -334,9 +317,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "go_goroutines{pod=\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "query": "sum(increase(pg_coordinator_remote_replica_recovery_total{namespace=\"$namespace\", pod=~\"${app}-.*\"}[24h])) or vector(0)"
                   }
                 }
               }
@@ -348,7 +329,8 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Network I/O"
+            "name": "Lag Behind Source (bytes)",
+            "description": "From the coordinator: source pg_current_wal_lsn() minus local replay LSN. Sampled every 5s while catching up, backing off to 300s while in sync \u2014 spikes shorter than the sampling interval may not appear."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
@@ -365,26 +347,8 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "rate(redis_net_input_bytes_total{pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": "{{ input }}"
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "global-ds-proxy"
-                    },
-                    "minStep": "",
-                    "query": "rate(redis_net_output_bytes_total{pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": "{{ output }}"
+                    "query": "pg_coordinator_remote_replica_lag_bytes{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
+                    "seriesNameFormat": "{{pod}}"
                   }
                 }
               }
@@ -396,7 +360,8 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Redis sentinel connected clients"
+            "name": "Apply Lag (seconds, exporter)",
+            "description": "From postgres_exporter: seconds since the last replayed transaction. CAVEAT: grows without bound while the SOURCE IS IDLE \u2014 read it together with the bytes panel."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
@@ -413,9 +378,8 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "redis_connected_clients{pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "query": "pg_replication_lag_seconds{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
+                    "seriesNameFormat": "{{pod}}"
                   }
                 }
               }
@@ -427,8 +391,8 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Average CPU Usage",
-            "description": "Average user and system CPU time spent in seconds."
+            "name": "Recovery Actions (rate/h)",
+            "description": "Coordinator-initiated pg_rewind and pg_basebackup attempts."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
@@ -445,9 +409,8 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "avg(rate(process_cpu_seconds_total{pod=\"$pod\", namespace=\"$namespace\"}[5m]) * 1000)",
-                    "seriesNameFormat": "used"
+                    "query": "sum by (action,result) (increase(pg_coordinator_remote_replica_recovery_total{namespace=\"$namespace\", pod=~\"${app}-.*\"}[1h]))",
+                    "seriesNameFormat": "{{action}}/{{result}}"
                   }
                 }
               }
@@ -459,8 +422,8 @@
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Average Memory Usage",
-            "description": "Virtual and Resident memory size in bytes, averages over 5 min interval"
+            "name": "Replica Mode (is_replica)",
+            "description": "1 while in recovery. A pod dropping to 0 here without a planned promotion is an incident."
           },
           "plugin": {
             "kind": "TimeSeriesChart",
@@ -477,13 +440,27 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "avg(rate(process_resident_memory_bytes{pod=\"$pod\", namespace=\"$namespace\"}[5m]))",
-                    "seriesNameFormat": "Resident Mem"
+                    "query": "pg_replication_is_replica{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
+                    "seriesNameFormat": "{{pod}}"
                   }
                 }
               }
-            },
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Backend Connections",
+            "description": "Total postgres backends per pod, summed over all databases and all connection states (pg_stat_activity, sampled at each Prometheus scrape). On an idle remote replica this is just the monitoring exporter and the KubeDB health checker \u2014 expect 0-2. A sustained rise means clients are connected through the standby service and actually reading from this replica. Legend values such as avg can be fractional because they average the sampled counts over the visible time window."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
             {
               "kind": "TimeSeriesQuery",
               "spec": {
@@ -494,9 +471,8 @@
                       "kind": "PrometheusDatasource",
                       "name": "global-ds-proxy"
                     },
-                    "minStep": "",
-                    "query": "avg(rate(process_virtual_memory_bytes{pod=\"$pod\", namespace=\"$namespace\"}[5m]))",
-                    "seriesNameFormat": "Virtual Mem"
+                    "query": "sum by (pod) (pg_stat_activity_count{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
+                    "seriesNameFormat": "{{pod}}"
                   }
                 }
               }
@@ -516,43 +492,43 @@
             {
               "x": 0,
               "y": 1,
-              "width": 8,
-              "height": 3,
+              "width": 4,
+              "height": 4,
               "content": {
                 "$ref": "#/spec/panels/0"
               }
             },
             {
-              "x": 8,
+              "x": 4,
               "y": 1,
               "width": 4,
-              "height": 3,
+              "height": 4,
               "content": {
                 "$ref": "#/spec/panels/1"
               }
             },
             {
-              "x": 12,
+              "x": 8,
               "y": 1,
-              "width": 12,
-              "height": 7,
+              "width": 5,
+              "height": 4,
               "content": {
                 "$ref": "#/spec/panels/2"
               }
             },
             {
-              "x": 0,
-              "y": 4,
-              "width": 8,
+              "x": 13,
+              "y": 1,
+              "width": 5,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/3"
               }
             },
             {
-              "x": 8,
-              "y": 4,
-              "width": 4,
+              "x": 18,
+              "y": 1,
+              "width": 6,
               "height": 4,
               "content": {
                 "$ref": "#/spec/panels/4"
@@ -560,38 +536,47 @@
             },
             {
               "x": 0,
-              "y": 8,
+              "y": 6,
               "width": 12,
-              "height": 7,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/5"
               }
             },
             {
               "x": 12,
-              "y": 8,
+              "y": 6,
               "width": 12,
-              "height": 7,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/6"
               }
             },
             {
               "x": 0,
-              "y": 16,
-              "width": 12,
+              "y": 15,
+              "width": 8,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/7"
               }
             },
             {
-              "x": 12,
-              "y": 16,
-              "width": 12,
+              "x": 8,
+              "y": 15,
+              "width": 8,
               "height": 8,
               "content": {
                 "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 16,
+              "y": 15,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/9"
               }
             }
           ]

--- a/postgres/postgres_remote_replica_dashboard-perses.json
+++ b/postgres/postgres_remote_replica_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "dr",
+      "kubedb",
+      "postgres",
+      "remote-replica"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/postgres/postgres_summary_dashboard-perses.json
+++ b/postgres/postgres_summary_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "postgres",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/postgres/postgres_summary_dashboard-perses.json
+++ b/postgres/postgres_summary_dashboard-perses.json
@@ -1647,6 +1647,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1655,49 +1697,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/proxysql/proxysql-summary-perses.json
+++ b/proxysql/proxysql-summary-perses.json
@@ -1226,6 +1226,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1234,49 +1276,7 @@
                   }
                 ]
               },
-              "metricLabel": "terminationPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "terminationPolicy"
             }
           },
           "queries": [

--- a/proxysql/proxysql-summary-perses.json
+++ b/proxysql/proxysql-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "proxysql",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/qdrant/qdrant_database_dashboard-perses.json
+++ b/qdrant/qdrant_database_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "database",
+      "kubedb",
+      "qdrant"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/qdrant/qdrant_pod_dashboard-perses.json
+++ b/qdrant/qdrant_pod_dashboard-perses.json
@@ -158,6 +158,28 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "background_solid",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#f2495c",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "Up"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/qdrant/qdrant_pod_dashboard-perses.json
+++ b/qdrant/qdrant_pod_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "kubedb",
+      "monitoring",
+      "performance",
+      "qdrant"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/qdrant/qdrant_summary_dashboard-perses.json
+++ b/qdrant/qdrant_summary_dashboard-perses.json
@@ -1308,6 +1308,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1316,49 +1358,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/qdrant/qdrant_summary_dashboard-perses.json
+++ b/qdrant/qdrant_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "qdrant",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/rabbitmq/rabbitmq-database-perses.json
+++ b/rabbitmq/rabbitmq-database-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "kubedb",
+      "rabbitmq"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/rabbitmq/rabbitmq-pod-perses.json
+++ b/rabbitmq/rabbitmq-pod-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "rabbitmq",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/rabbitmq/rabbitmq-pod-perses.json
+++ b/rabbitmq/rabbitmq-pod-perses.json
@@ -117,6 +117,27 @@
                 "decimalPlaces": 1,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Running"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/rabbitmq/rabbitmq-summary-perses.json
+++ b/rabbitmq/rabbitmq-summary-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "rabbitmq",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/rabbitmq/rabbitmq-summary-perses.json
+++ b/rabbitmq/rabbitmq-summary-perses.json
@@ -1266,6 +1266,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1274,49 +1316,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/redis/redis_pod_dashboard-perses.json
+++ b/redis/redis_pod_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "redis",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/redis/redis_pod_dashboard-perses.json
+++ b/redis/redis_pod_dashboard-perses.json
@@ -114,6 +114,27 @@
                 "decimalPlaces": 1,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Running"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -160,6 +181,37 @@
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "master"
+                    },
+                    "value": "master"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#8ab8ff",
+                      "value": "slave"
+                    },
+                    "value": "slave"
+                  }
+                },
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "result": {
+                      "value": "N/A"
+                    },
+                    "value": "null"
+                  }
+                }
+              ],
               "metricLabel": "role",
               "thresholds": {
                 "steps": [

--- a/redis/redis_shards_dashboard-perses.json
+++ b/redis/redis_shards_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "redis",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/redis/redis_summary_dashboard-perses.json
+++ b/redis/redis_summary_dashboard-perses.json
@@ -1531,6 +1531,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1539,49 +1581,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/redis/redis_summary_dashboard-perses.json
+++ b/redis/redis_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "redis",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/redis/sentinel_pod_dashboard-perses.json
+++ b/redis/sentinel_pod_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "redis",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/redis/sentinel_summary_dashbaord-perses.json
+++ b/redis/sentinel_summary_dashbaord-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "redissentinel",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/redis/sentinel_summary_dashbaord-perses.json
+++ b/redis/sentinel_summary_dashbaord-perses.json
@@ -1404,6 +1404,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1412,49 +1454,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/singlestore/singlestore_database_dashboard-perses.json
+++ b/singlestore/singlestore_database_dashboard-perses.json
@@ -5,6 +5,9 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "singlestore"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/singlestore/singlestore_pod_dashboard-perses.json
+++ b/singlestore/singlestore_pod_dashboard-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "pod",
+      "singlestore",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/singlestore/singlestore_summary_dashboard-perses.json
+++ b/singlestore/singlestore_summary_dashboard-perses.json
@@ -1265,6 +1265,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1273,49 +1315,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/singlestore/singlestore_summary_dashboard-perses.json
+++ b/singlestore/singlestore_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "singlestore",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/solr/solr-database-perses.json
+++ b/solr/solr-database-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "database",
+      "kubedb",
+      "solr"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/solr/solr-pod-perses.json
+++ b/solr/solr-pod-perses.json
@@ -5,6 +5,10 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "kubedb",
+      "solr"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/solr/solr-summary-perses.json
+++ b/solr/solr-summary-perses.json
@@ -5,6 +5,11 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "stats"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/solr/solr-summary-perses.json
+++ b/solr/solr-summary-perses.json
@@ -1588,6 +1588,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1596,49 +1638,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [

--- a/zookeeper/zookeeper_ensemble_dashboard-perses.json
+++ b/zookeeper/zookeeper_ensemble_dashboard-perses.json
@@ -482,7 +482,7 @@
           "plugin": {
             "kind": "StatChart",
             "spec": {
-              "calculation": "mean",
+              "calculation": "last-number",
               "colorMode": "background_solid",
               "format": {
                 "unit": "milliseconds"

--- a/zookeeper/zookeeper_pod_dashboard-perses.json
+++ b/zookeeper/zookeeper_pod_dashboard-perses.json
@@ -115,6 +115,27 @@
                 "decimalPlaces": 1,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Down"
+                    },
+                    "value": "0"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "value": "Running"
+                    },
+                    "value": "1"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -160,6 +181,17 @@
               "format": {
                 "unit": "milliseconds"
               },
+              "mappings": [
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "result": {
+                      "value": "Follower"
+                    },
+                    "value": "null"
+                  }
+                }
+              ],
               "metricLabel": "Leader",
               "thresholds": {
                 "steps": [
@@ -810,7 +842,7 @@
           "plugin": {
             "kind": "StatChart",
             "spec": {
-              "calculation": "mean",
+              "calculation": "last-number",
               "colorMode": "background_solid",
               "format": {
                 "unit": "milliseconds"

--- a/zookeeper/zookeeper_summary_dashboard-perses.json
+++ b/zookeeper/zookeeper_summary_dashboard-perses.json
@@ -5,6 +5,12 @@
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
+    "tags": [
+      "db",
+      "kubedb",
+      "stats",
+      "zookeeper"
+    ],
     "project": "pp"
   },
   "spec": {

--- a/zookeeper/zookeeper_summary_dashboard-perses.json
+++ b/zookeeper/zookeeper_summary_dashboard-perses.json
@@ -1344,13 +1344,12 @@
           "plugin": {
             "kind": "StatChart",
             "spec": {
-              "calculation": "mean",
+              "calculation": "last-number",
               "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
               "metricLabel": "instance",
-              "sparkline": {},
               "thresholds": {
                 "steps": [
                   {
@@ -1398,6 +1397,48 @@
             "spec": {
               "calculation": "last-number",
               "colorMode": "none",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#fade2a",
+                      "value": "Delete"
+                    },
+                    "value": "Delete"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#73bf69",
+                      "value": "DoNotTerminate"
+                    },
+                    "value": "DoNotTerminate"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "Halt"
+                    },
+                    "value": "Halt"
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "result": {
+                      "color": "#c4162a",
+                      "value": "WipeOut"
+                    },
+                    "value": "WipeOut"
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1406,49 +1447,7 @@
                   }
                 ]
               },
-              "metricLabel": "deletionPolicy",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "WipeOut",
-                    "result": {
-                      "color": "#c4162a",
-                      "value": "WipeOut"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Delete",
-                    "result": {
-                      "color": "#f2cc0c",
-                      "value": "Delete"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "Halt",
-                    "result": {
-                      "color": "#5794f2",
-                      "value": "Halt"
-                    }
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "value": "DoNotTerminate",
-                    "result": {
-                      "color": "#73bf69",
-                      "value": "DoNotTerminate"
-                    }
-                  }
-                }
-              ]
+              "metricLabel": "deletionPolicy"
             }
           },
           "queries": [


### PR DESCRIPTION
Output of `run.bash` from opnpulse/perses-dashboards#4, which encodes the rules of #112 and #104 in the generator instead of leaving them as hand edits to generated files. Before that PR, every regeneration silently reverted both commits.

**Merge opnpulse/perses-dashboards#4 first.** This PR is generated output — regenerating after that merge reproduces it exactly.

---

# What to review

## 1. The 11 files that change rendering — worth opening in Perses

These panels render a raw `1` today and will render `Running` / `master` after this PR. They are the same bug class as #112/#104 on panels the hand edits never reached: their Grafana source uses the pre-v8 mapping format, `percli migrate` rejected it, so the mappings were silently dropped and nobody noticed.

| File | Panels |
|---|---|
| `ignite/ignite_database_dashboard-perses.json` | Status |
| `ignite/ignite_pod_dashboard-perses.json` | Status |
| `mssqlserver/mssqlserver_pod_dashboard-perses.json` | Status |
| `oracle/oracle_pod_dashboard-perses.json` | Status |
| `qdrant/qdrant_pod_dashboard-perses.json` | Status |
| `rabbitmq/rabbitmq-pod-perses.json` | Status |
| `redis/redis_pod_dashboard-perses.json` | Status, Role |
| `redis/sentinel_pod_dashboard-perses.json` | Status |
| `zookeeper/zookeeper_pod_dashboard-perses.json` | Status, Role |
| `mongodb/legacy/mongodb-database-replset-dashboard-perses.json` | ReplSet State |
| `mongodb/legacy/mongodb-summary-dashboard-perses.json` | Termination Policy |

**Question for you:** this is scope beyond the two commits I was asked to port. Say the word and I will drop it — it costs one line in `cleaning5.py`.

## 2. One new file

`postgres/postgres_remote_replica_dashboard-perses.json`. The Grafana source landed in #111; its Perses variant was never generated. Nothing else references it yet.

## 3. Everything else — 38 files, mechanical

Restores exactly what #112 and #104 hand-wrote. No judgment needed; the diffs repeat the same handful of shapes.

---

# What changed

Of **107** tracked `*-perses.json` files: **48 modified, 1 added, 58 byte-identical.**

Reproduced by the pipeline instead of by hand:

| | |
|---|---|
| `metricLabel` on label-valued stat panels | 85 panels |
| `seriesNameFormat` `{{ x }}` / `{{x}} ` → `{{x}}` | 33 queries |
| `sparkline: {}` dropped behind text values | 85 panels |
| `calculation: mean` → `last-number` | 32 panels |
| Value mappings preserved through migration | 30 Deletion / Termination Policy panels |
| Table `pod` → `pod #1..#N` | 90 tables |
| Role mapping colors from #104 | mssqlserver, oracle, postgres |

Plus the 13 panels in section 1, three `mongodb/legacy/mongodb-summary` tables whose `pod` column #112 missed, and `mongodb/legacy` Storage Engine (`" engine "` → `engine`).

# What is unchanged

- **58 dashboards regenerate byte-identical** to master, including every file in `falco`, `kubestash`, `policy`, `scanner`, `stash`. The pipeline is deterministic; anything not listed above is untouched.
- **No Grafana source JSON is modified.** This PR only touches generated `*-perses.json`.
- **No queries, thresholds, layouts, panel titles or variables change.** The diff is confined to `metricLabel`, `seriesNameFormat`, `sparkline`, `calculation`, `mappings` and table `columnSettings`.

# Known residuals — not fixed here

- **milvus / neo4j "Require Secure Transport"** keep a sparkline and are not promoted to a label display. Their Grafana source changed since #112: `legendFormat` is now `{{issuers_name}}`, not `{{requireSSL}}`. Promoting it would show the TLS issuer name instead of True/False, so I left the source semantics alone. Belongs in the Grafana JSON.
- **neo4j "TLS Channels"** table emits raw migrated columns instead of the single `Channel` column on master. Unrelated source drift, not a `pod`-column case.
- **zookeeper `Leader` / `leader`** switch `mean` → `last-number`. Cosmetic, consistent with every other label-valued panel.
- **`ReplSet State`** on mongodb-database-replset gains a `0 → STARTUP` entry and reorders mapping keys. Superset of master, semantically identical.
- Mapping colors differ by hex for the same Grafana color name (`yellow` → `#fade2a` vs the hand-written `#f2cc0c`). `percli`'s palette; not worth overriding.

# Verification

Wiped and regenerated all 34 folders from a clean tree: **34/34 migrate and `percli apply` clean**, zero failures. Then compared every panel against master by display name — the residuals above are the complete list of differences.
